### PR TITLE
[Fix] - CD deploy.sh 실행 경로 수정

### DIFF
--- a/.github/workflows/be-dev-ci-cd.yml
+++ b/.github/workflows/be-dev-ci-cd.yml
@@ -47,5 +47,11 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - name: Pull the Docker Image and deploy
-        run: ../deploy.sh
+      - name: Docker Image pull
+        run: sudo docker pull touroot/touroot-api
+
+      - name: Move to Docker directory
+        run: cd ~/docker
+
+      - name: Docker Compose up
+        run: sudo docker compose -f touroot-docker.yml up -d


### PR DESCRIPTION
# ✅ 작업 내용

- deploy.sh을 활용하지 않도록 결정
- 명령어를 Github Actions workflow에서 직접 실행
- Github Actions workflow 파일 이름 변경
