### PR TITLE
[Fix] - 업로드한 이미지 url에 접속하면 이미지를 열지 않고 다운로드 받는 버그 해결

### DIFF
--- a/backend/src/main/java/woowacourse/touroot/image/infrastructure/AwsS3Provider.java
+++ b/backend/src/main/java/woowacourse/touroot/image/infrastructure/AwsS3Provider.java
@@ -65,6 +65,8 @@ public class AwsS3Provider {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(filePath)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
                     .build();
 
             s3Client.putObject(putObjectRequest, requestBody);


### PR DESCRIPTION
# ✅ 작업 내용

- S3에 이미지 업로드 요청시 ContentType을 원본 파일의 ContentType으로 설정함으로서 이미지가 다운로드 되는 버그 해결

# 🙈 참고 사항
