### PR TITLE
[Fix] - 업로드 이미지 용량 조정

### DIFF
--- a/backend/src/main/java/woowacourse/touroot/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/woowacourse/touroot/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import woowacourse.touroot.global.exception.dto.ExceptionResponse;
 
 @Slf4j
@@ -41,5 +42,13 @@ public class GlobalExceptionHandler {
 
         ExceptionResponse data = new ExceptionResponse(exception.getMessage());
         return ResponseEntity.internalServerError().body(data);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ExceptionResponse> handleUploadExceedException(MaxUploadSizeExceededException exception) {
+        log.info("UPLOAD_SIZE_EXCEPTION :: message = {}", exception.getMessage());
+
+        ExceptionResponse data = new ExceptionResponse("파일 업로드 용량을 초과하였습니다.");
+        return ResponseEntity.badRequest().body(data);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -52,6 +52,10 @@ server:
     key-store-password: ENC(aIkhk+PERnL/OBpa2HtNyXAjOGbCZx9TJ+L5sekBxdI=)
     key-store: ENC(7VQCNdI7mXATwc4AiymZoyf3mz9SiskXpLnenpMSFBI=)
 spring:
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 50MB
   config:
     activate:
       on-profile: dev


### PR DESCRIPTION
# ✅ 작업 내용

- 파일 업로드 용량 조정
    - 개별 파일 5mb까지 허용
    - 총 요청 50mb까지 허용
- 파일 업로드 예외 전역 처리기에서 처리하도록 수정
