### PR TITLE
[Feature] - 로그인 명세 수정 개선

### DIFF
--- a/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
+++ b/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
@@ -11,7 +11,7 @@ import kr.touroot.authentication.service.LoginService;
 import kr.touroot.global.exception.dto.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,7 +36,7 @@ public class LoginController {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    @PostMapping("/oauth/kakao")
+    @GetMapping("/oauth/kakao")
     public ResponseEntity<LoginResponse> login(@RequestParam(name = "code") String authorizationCode) {
         return ResponseEntity.ok()
                 .body(loginService.login(authorizationCode));

--- a/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
+++ b/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
@@ -11,7 +11,7 @@ import kr.touroot.authentication.service.LoginService;
 import kr.touroot.global.exception.dto.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,9 +36,8 @@ public class LoginController {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    @GetMapping("/oauth/kakao")
-    public ResponseEntity<LoginResponse> login(
-            @RequestParam(name = "code") String authorizationCode) {
+    @PostMapping("/oauth/kakao")
+    public ResponseEntity<LoginResponse> login(@RequestParam(name = "code") String authorizationCode) {
         return ResponseEntity.ok()
                 .body(loginService.login(authorizationCode));
     }

--- a/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
+++ b/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
@@ -11,7 +11,7 @@ import kr.touroot.authentication.service.LoginService;
 import kr.touroot.global.exception.dto.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,8 +36,9 @@ public class LoginController {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    @PostMapping("/oauth/kakao")
-    public ResponseEntity<LoginResponse> login(@RequestParam(name = "code") String authorizationCode) {
+    @GetMapping("/oauth/kakao")
+    public ResponseEntity<LoginResponse> login(
+            @RequestParam(name = "code") String authorizationCode) {
         return ResponseEntity.ok()
                 .body(loginService.login(authorizationCode));
     }

--- a/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             new HttpRequestInfo(HttpMethod.GET, "/v3/api-docs/**"),
             new HttpRequestInfo(HttpMethod.GET, "/api/v1/travelogues/**"),
             new HttpRequestInfo(HttpMethod.GET, "/api/v1/travel-plans/**"),
-            new HttpRequestInfo(HttpMethod.POST, "/api/v1/login/**"),
+            new HttpRequestInfo(HttpMethod.GET, "/api/v1/login/**"),
             new HttpRequestInfo(HttpMethod.OPTIONS, "/**")
     );
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,9 @@ spring:
   config:
     activate:
       on-profile: local
+oauth:
+  kakao:
+    redirect-uri: http://localhost:8080/api/v1/login/oauth/kakao
   h2:
     console:
       enabled: true


### PR DESCRIPTION
# ✅ 작업 내용

- 로그인 HTTP Method GET으로 변경 

# 🙈 참고 사항

로컬에서의 Oauth로그인을 원활히 실행하기 위해 인가가 구현될때까지 임시적으로 GET처리합니다.
인가 쪽 구현이 굳어지면 명세가 다시 바뀌어야 합니다. 
- Login Api는 accessToken이 계속 바뀜으로 멱등하지 않음
- 서버 상태를 바꾸기에 POST가 적절(회원가입도 하기 때문)
떼껄룩에 적어놓을게요. 인가쪽 구현이 완료되면 명세 다시 수정겠습니다.