### PR TITLE
[Feature] - 사용하지 않는 S3 이미지 관리 기능 구현

### DIFF
--- a/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
+++ b/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
@@ -20,16 +20,16 @@ public class AwsS3Provider {
 
     private final String bucket;
     private final String imageBaseUri;
-    private final String directoryPath;
+    private final String temporaryStoragePath;
 
     public AwsS3Provider(
             @Value("${cloud.aws.s3.bucket}") String bucket,
             @Value("${cloud.aws.s3.image-base-uri}") String imageBaseUri,
-            @Value("${cloud.aws.s3.directory-path}") String directoryPath
+            @Value("${cloud.aws.s3.temporary-storage-path}") String temporaryStoragePath
     ) {
         this.bucket = bucket;
         this.imageBaseUri = imageBaseUri;
-        this.directoryPath = directoryPath;
+        this.temporaryStoragePath = temporaryStoragePath;
     }
 
     public List<String> uploadImages(List<ImageFile> files) {
@@ -40,7 +40,7 @@ public class AwsS3Provider {
                     .map(ImageFile::getFile)
                     .forEach(file -> {
                         String newFileName = createNewFileName(file.getOriginalFilename());
-                        String filePath = directoryPath + newFileName;
+                        String filePath = temporaryStoragePath + newFileName;
                         uploadFile(file, filePath, s3Client);
                         urls.add(imageBaseUri + newFileName);
                     });

--- a/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
+++ b/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
@@ -29,7 +29,7 @@ public class AwsS3Provider {
     public AwsS3Provider(
             @Value("${cloud.aws.s3.bucket}") String bucket,
             @Value("${cloud.aws.s3.image-base-uri}") String imageBaseUri,
-            @Value("${cloud.aws.s3.touroot-storage-path}") String tourootStoragePath,
+            @Value("${cloud.aws.s3.base-storage-path}") String tourootStoragePath,
             @Value("${cloud.aws.s3.temporary-storage-path}") String temporaryStoragePath,
             @Value("${cloud.aws.s3.image-storage-path}") String imageStoragePath
     ) {

--- a/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
+++ b/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import kr.touroot.global.exception.BadRequestException;
+import kr.touroot.image.domain.ImageFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,8 +16,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import kr.touroot.global.exception.BadRequestException;
-import kr.touroot.image.domain.ImageFile;
 
 @Component
 public class AwsS3Provider {
@@ -98,7 +98,7 @@ public class AwsS3Provider {
     }
 
     private void copyFile(String sourceKey, String destinationKey) {
-        try {
+        try (S3Client s3Client = getS3Client()) {
             CopyObjectRequest request = CopyObjectRequest.builder()
                     .sourceBucket(bucket)
                     .sourceKey(sourceKey)
@@ -106,9 +106,7 @@ public class AwsS3Provider {
                     .destinationKey(destinationKey)
                     .build();
 
-            S3Client s3Client = getS3Client();
             s3Client.copyObject(request);
-            s3Client.close();
         } catch (NoSuchKeyException e) {
             throw new BadRequestException("복사하려는 사진이 존재하지 않습니다.");
         }

--- a/backend/src/main/java/kr/touroot/travelogue/dto/request/TraveloguePhotoRequest.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/request/TraveloguePhotoRequest.java
@@ -10,8 +10,4 @@ public record TraveloguePhotoRequest(
         @NotNull(message = "여행기 장소 사진 URL 값은 비어있을 수 없습니다.")
         String url
 ) {
-
-    public TraveloguePhoto toTraveloguePhoto(int order, TraveloguePlace traveloguePlace) {
-        return new TraveloguePhoto(order, url, traveloguePlace);
-    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueRequest.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueRequest.java
@@ -11,8 +11,8 @@ public record TravelogueRequest(
         @Schema(description = "여행기 제목", example = "서울 강남 여행기")
         @NotNull(message = "여행기 제목은 비어있을 수 없습니다.")
         String title,
-        @Schema(description = "여행기 섬네일", example = "https://thumbnail.png")
-        @NotNull(message = "여행기 섬네일은 비어있을 수 없습니다.")
+        @Schema(description = "여행기 썸네일", example = "https://thumbnail.png")
+        @NotNull(message = "여행기 썸네일은 비어있을 수 없습니다.")
         String thumbnail,
         @Schema(description = "여행기 일자 목록")
         @NotNull(message = "여행기 일자 목록은 비어있을 수 없습니다.")

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
@@ -15,8 +15,8 @@ public record TravelogueResponse(
         @Schema(description = "여행기 제목", example = "서울 강남 여행기")
         @NotNull(message = "여행기 제목은 비어있을 수 없습니다.")
         String title,
-        @Schema(description = "여행기 섬네일 링크", example = "https://섬네일.png")
-        @NotNull(message = "여행기 섬네일 링크는 비어있을 수 없습니다.")
+        @Schema(description = "여행기 썸네일 링크", example = "https://썸네일.png")
+        @NotNull(message = "여행기 썸네일 링크는 비어있을 수 없습니다.")
         String thumbnail,
         @Schema(description = "여행기 일자 목록")
         @NotNull(message = "여행기 일자 목록은 비어있을 수 없습니다.")

--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
@@ -3,25 +3,29 @@ package kr.touroot.travelogue.service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.travelogue.domain.TraveloguePhoto;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.repository.TraveloguePhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @RequiredArgsConstructor
 @Service
 public class TraveloguePhotoService {
 
     private final TraveloguePhotoRepository traveloguePhotoRepository;
+    private final AwsS3Provider s3Provider;
 
     public List<TraveloguePhoto> createPhotos(List<TraveloguePhotoRequest> requests, TraveloguePlace place) {
         List<TraveloguePhoto> photos = new ArrayList<>();
 
         for (int i = 0; i < requests.size(); i++) {
             TraveloguePhotoRequest request = requests.get(i);
-            TraveloguePhoto photo = request.toTraveloguePhoto(i, place);
+            String url = s3Provider.copyImageToPermanentStorage(request.url());
+            TraveloguePhoto photo = new TraveloguePhoto(i, url, place);
             photos.add(traveloguePhotoRepository.save(photo));
         }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,7 +13,7 @@ cloud:
     s3:
       bucket: techcourse-project-2024
       image-base-uri: https://dev.touroot.kr/
-      touroot-storage-path: touroot/
+      base-storage-path: touroot/
       temporary-storage-path: temporary/
       image-storage-path: images/
 ---

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,9 +12,10 @@ cloud:
   aws:
     s3:
       bucket: techcourse-project-2024
-      image-base-uri: https://dev.touroot.kr/images/
-      temporary-storage-path: touroot/temporary/
-      permanent-storage-path: touroot/images/
+      image-base-uri: https://dev.touroot.kr/
+      touroot-storage-path: touroot/
+      temporary-storage-path: temporary/
+      image-storage-path: images/
 ---
 security:
   jwt:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,7 +13,8 @@ cloud:
     s3:
       bucket: techcourse-project-2024
       image-base-uri: https://dev.touroot.kr/images/
-      directory-path: touroot/images/
+      temporary-storage-path: touroot/temporary/
+      permanent-storage-path: touroot/images/
 ---
 security:
   jwt:

--- a/backend/src/test/java/kr/touroot/image/infrastructure/AwsS3ProviderTest.java
+++ b/backend/src/test/java/kr/touroot/image/infrastructure/AwsS3ProviderTest.java
@@ -1,28 +1,70 @@
 package kr.touroot.image.infrastructure;
 
+import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import io.restassured.RestAssured;
+import kr.touroot.authentication.fixture.OauthUserInformationFixture;
 import kr.touroot.global.AcceptanceTest;
 import kr.touroot.global.exception.BadRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = AwsS3Provider.class)
 class AwsS3ProviderTest {
 
-    @Autowired
-    AwsS3Provider s3Provider;
+    @MockBean
+    private S3Client s3Client;
+
+    @SpyBean
+    private AwsS3Provider s3Provider;
+
+    @Value("${cloud.aws.s3.image-base-uri}")
+    private String imageBaseUri;
+    @Value("${cloud.aws.s3.temporary-storage-path}")
+    private String temporaryStoragePath;
+    @Value("${cloud.aws.s3.image-storage-path}")
+    private String imageStoragePath;
+
+    @DisplayName("유효한 url을 통해 이미지를 영구 폴더로 복사하면 새로운 url을 반환한다.")
+    @Test
+    void copyImageToPermanentStorage() {
+        when(s3Provider.getS3Client())
+                .thenReturn(s3Client);
+        when(s3Client.copyObject(any(CopyObjectRequest.class)))
+                .thenReturn(CopyObjectResponse.builder().build());
+
+        String temporaryUrl = imageBaseUri + temporaryStoragePath + "valid.png";
+        String imageUrl = imageBaseUri + imageStoragePath + "valid.png";
+        assertThat(s3Provider.copyImageToPermanentStorage(temporaryUrl))
+                .isEqualTo(imageUrl);
+    }
 
     @DisplayName("url이 올바른 버킷명과 폴더명으로 시작하지 않으면 예외를 발생한다.")
     @Test
     void copyImageToPermanentStorageWithInvalidPath() {
-        String imageUrl = "testUrl";
+        String imageUrl = "invalid/testUrl.png";
         assertThatThrownBy(() -> s3Provider.copyImageToPermanentStorage(imageUrl))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("이미지 url 형식이 잘못되었습니다.");

--- a/backend/src/test/java/kr/touroot/image/infrastructure/AwsS3ProviderTest.java
+++ b/backend/src/test/java/kr/touroot/image/infrastructure/AwsS3ProviderTest.java
@@ -1,0 +1,30 @@
+package kr.touroot.image.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import kr.touroot.global.AcceptanceTest;
+import kr.touroot.global.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = AwsS3Provider.class)
+class AwsS3ProviderTest {
+
+    @Autowired
+    AwsS3Provider s3Provider;
+
+    @DisplayName("url이 올바른 버킷명과 폴더명으로 시작하지 않으면 예외를 발생한다.")
+    @Test
+    void copyImageToPermanentStorageWithInvalidPath() {
+        String imageUrl = "testUrl";
+        assertThatThrownBy(() -> s3Provider.copyImageToPermanentStorage(imageUrl))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미지 url 형식이 잘못되었습니다.");
+    }
+}

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueFixture.java
@@ -4,7 +4,7 @@ import kr.touroot.travelogue.domain.Travelogue;
 
 public enum TravelogueFixture {
 
-    TRAVELOGUE("제주에 하영 옵서", "https://url.com/jeju_thumbnail.png");
+    TRAVELOGUE("제주에 하영 옵서", "https://dev.touroot.kr/temporary/jeju_thumbnail.png");
 
     private final String title;
     private final String thumbnail;

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TraveloguePhotoFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TraveloguePhotoFixture.java
@@ -7,7 +7,7 @@ import kr.touroot.travelogue.domain.TraveloguePlace;
 
 public enum TraveloguePhotoFixture {
 
-    TRAVELOGUE_PHOTO(1, "https://image-url.com/image1.png", TRAVELOGUE_PLACE.get());
+    TRAVELOGUE_PHOTO(1, "https://dev.touroot.kr/temporary/image1.png", TRAVELOGUE_PLACE.get());
 
     private final int order;
     private final String url;

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueRequestFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueRequestFixture.java
@@ -15,7 +15,7 @@ public class TravelogueRequestFixture {
     }
 
     public static TravelogueRequest getTravelogueRequest() {
-        return new TravelogueRequest("제주에 하영 옵서", "https://url.com/jeju_thumbnail.png", getTravelogueDayRequests());
+        return new TravelogueRequest("제주에 하영 옵서", "https://dev.touroot.kr/temporary/jeju_thumbnail.png", getTravelogueDayRequests());
     }
 
     public static List<TravelogueDayRequest> getTravelogueDayRequests() {
@@ -36,6 +36,6 @@ public class TravelogueRequestFixture {
     }
 
     public static List<TraveloguePhotoRequest> getTraveloguePhotoRequests() {
-        return List.of(new TraveloguePhotoRequest("https://image-url.com/image1.png"));
+        return List.of(new TraveloguePhotoRequest("https://dev.touroot.kr/temporary/image1.png"));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
@@ -19,7 +19,7 @@ public class TravelogueResponseFixture {
         return TravelogueResponse.builder()
                 .id(1L)
                 .title("제주에 하영 옵서")
-                .thumbnail("https://url.com/jeju_thumbnail.png")
+                .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                 .days(getTravelogueDayResponses())
                 .build();
     }
@@ -28,7 +28,7 @@ public class TravelogueResponseFixture {
         return new PageImpl<>(List.of(TravelogueResponse.builder()
                 .id(1L)
                 .title("제주에 하영 옵서")
-                .thumbnail("https://url.com/jeju_thumbnail.png")
+                .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                 .days(getTravelogueDayResponses())
                 .build()));
     }
@@ -60,6 +60,6 @@ public class TravelogueResponseFixture {
     }
 
     public static List<String> getTraveloguePhotoUrls() {
-        return List.of("https://image-url.com/image1.png");
+        return List.of("https://dev.touroot.kr/temporary/image1.png");
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -3,6 +3,7 @@ package kr.touroot.travelogue.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import kr.touroot.global.ServiceTest;
+import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.response.TravelogueResponse;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
@@ -25,6 +26,7 @@ import org.springframework.data.domain.Pageable;
         TravelogueDayService.class,
         TraveloguePlaceService.class,
         TravelogueTestHelper.class,
+        AwsS3Provider.class,
 })
 @ServiceTest
 class TravelogueFacadeServiceTest {

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelogue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 
 import kr.touroot.global.ServiceTest;
 import kr.touroot.image.infrastructure.AwsS3Provider;
@@ -13,7 +14,9 @@ import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +37,8 @@ class TravelogueFacadeServiceTest {
     private final TravelogueFacadeService service;
     private final TravelogueTestHelper testHelper;
     private final DatabaseCleaner databaseCleaner;
+    @MockBean
+    private final AwsS3Provider s3Provider;
 
     @BeforeEach
     void setUp() {
@@ -44,16 +49,21 @@ class TravelogueFacadeServiceTest {
     public TravelogueFacadeServiceTest(
             TravelogueFacadeService travelogueFacadeService,
             TravelogueTestHelper travelogueTestHelper,
-            DatabaseCleaner databaseCleaner
+            DatabaseCleaner databaseCleaner,
+            AwsS3Provider s3Provider
     ) {
         this.service = travelogueFacadeService;
         this.testHelper = travelogueTestHelper;
         this.databaseCleaner = databaseCleaner;
+        this.s3Provider = s3Provider;
     }
 
     @DisplayName("여행기를 생성할 수 있다.")
     @Test
     void createTravelogue() {
+        Mockito.when(s3Provider.copyImageToPermanentStorage(any(String.class)))
+                .thenReturn(TravelogueResponseFixture.getTraveloguePhotoUrls().get(0));
+
         TravelogueRequest request = TravelogueRequestFixture.getTravelogueRequest();
 
         assertThat(service.createTravelogue(request))

--- a/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelogue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.List;
 import kr.touroot.global.ServiceTest;
@@ -15,7 +16,10 @@ import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
 import kr.touroot.travelogue.helper.TravelogueTestHelper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 @DisplayName("여행기 사진 서비스")
@@ -25,16 +29,26 @@ class TraveloguePhotoServiceTest {
 
     private final TraveloguePhotoService photoService;
     private final TravelogueTestHelper testHelper;
+    @MockBean
+    private final AwsS3Provider s3Provider;
 
     @Autowired
-    public TraveloguePhotoServiceTest(TraveloguePhotoService photoService, TravelogueTestHelper testHelper) {
+    public TraveloguePhotoServiceTest(
+            TraveloguePhotoService photoService,
+            TravelogueTestHelper testHelper,
+            AwsS3Provider s3Provider
+    ) {
         this.photoService = photoService;
         this.testHelper = testHelper;
+        this.s3Provider = s3Provider;
     }
 
     @DisplayName("여행기 사진을 생성한다.")
     @Test
     void createPhotos() {
+        Mockito.when(s3Provider.copyImageToPermanentStorage(any(String.class)))
+                .thenReturn("imageUrl.png");
+
         List<TraveloguePhotoRequest> requests = TravelogueRequestFixture.getTraveloguePhotoRequests();
         Travelogue travelogue = testHelper.persistTravelogue();
         TravelogueDay day = testHelper.persistTravelogueDay(travelogue);

--- a/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import kr.touroot.global.ServiceTest;
+import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.place.domain.Place;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueDay;
@@ -18,7 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
 @DisplayName("여행기 사진 서비스")
-@Import(value = {TraveloguePhotoService.class, TravelogueTestHelper.class})
+@Import(value = {TraveloguePhotoService.class, TravelogueTestHelper.class, AwsS3Provider.class})
 @ServiceTest
 class TraveloguePhotoServiceTest {
 

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -14,7 +14,7 @@ cloud:
     s3:
       bucket: techcourse-project-2024
       image-base-uri: https://dev.touroot.kr/
-      touroot-storage-path: touroot/
+      base-storage-path: touroot/
       temporary-storage-path: temporary/
       image-storage-path: images/
 server:

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -13,9 +13,10 @@ cloud:
   aws:
     s3:
       bucket: techcourse-project-2024
-      image-base-uri: https://dev.touroot.kr/images/
-      temporary-storage-path: touroot/temporary/
-      permanent-storage-path: touroot/images/
+      image-base-uri: https://dev.touroot.kr/
+      touroot-storage-path: touroot/
+      temporary-storage-path: temporary/
+      image-storage-path: images/
 server:
   port: 8081
 spring:

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -14,7 +14,8 @@ cloud:
     s3:
       bucket: techcourse-project-2024
       image-base-uri: https://dev.touroot.kr/images/
-      directory-path: touroot/images/
+      temporary-storage-path: touroot/temporary/
+      permanent-storage-path: touroot/images/
 server:
   port: 8081
 spring:


### PR DESCRIPTION
# ✅ 작업 내용

- Image를 임시 디렉토리로 업로드하도록 수정
- S3 임시 디렉토리 수명주기 설정
- 영구 디렉토리로 복사 기능 구현
- 테스트 Fixture의 url 변경

# 🙈 참고 사항
- 현재 수명 주기가 제대로 적용됐는지 확인하기 위해 우선 1일로 설정해놓았습니다. 이후 확인이 완료되면 적절한 일수로 수정해야 할 것 같습니다.
- PhotoService에서 AwsS3Provider를 호출하는데 인증이 필요해서 Mock을 추가했습니다.