### PR TITLE
[Fix] - 썸네일 이미지 S3 영구 폴더 복사 기능 구현

### DIFF
--- a/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
+++ b/backend/src/main/java/kr/touroot/image/infrastructure/AwsS3Provider.java
@@ -84,11 +84,13 @@ public class AwsS3Provider {
         }
     }
 
-    public String copyImageToPermanentStorage(String imageKey) {
-        validateS3Path(imageKey);
-        String destinationKey = imageKey.replace(temporaryStoragePath, imageStoragePath);
-        copyFile(imageKey, destinationKey);
-        return destinationKey;
+    public String copyImageToPermanentStorage(String imageUrl) {
+        validateS3Path(imageUrl);
+        String fileName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+        String sourceKey = tourootStoragePath + temporaryStoragePath + fileName;
+        String destinationKey = sourceKey.replace(temporaryStoragePath, imageStoragePath);
+        copyFile(sourceKey, destinationKey);
+        return imageUrl.replace(temporaryStoragePath, imageStoragePath);
     }
 
     private void validateS3Path(String imageKey) {

--- a/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueRequest.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueRequest.java
@@ -23,7 +23,7 @@ public record TravelogueRequest(
         List<TravelogueDayRequest> days
 ) {
 
-    public Travelogue toTravelogueOf(Member author) {
-        return new Travelogue(author, title, thumbnail);
+    public Travelogue toTravelogueOf(Member author, String url) {
+        return new Travelogue(author, title, url);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelogue.service;
 
 import kr.touroot.global.exception.BadRequestException;
+import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
@@ -15,9 +16,11 @@ import org.springframework.stereotype.Service;
 public class TravelogueService {
 
     private final TravelogueRepository travelogueRepository;
+    private final AwsS3Provider s3Provider;
 
     public Travelogue createTravelogue(Member author, TravelogueRequest request) {
-        Travelogue travelogue = request.toTravelogueOf(author);
+        String url = s3Provider.copyImageToPermanentStorage(request.thumbnail());
+        Travelogue travelogue = request.toTravelogueOf(author, url);
         return travelogueRepository.save(travelogue);
     }
 

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -31,14 +31,14 @@ import org.springframework.http.HttpHeaders;
 @AcceptanceTest
 class TravelogueControllerTest {
 
-    @LocalServerPort
-    private int port;
     private final DatabaseCleaner databaseCleaner;
     private final TravelogueTestHelper testHelper;
     private final ObjectMapper objectMapper;
     private final JwtTokenProvider jwtTokenProvider;
     @MockBean
     private final AwsS3Provider s3Provider;
+    @LocalServerPort
+    private int port;
 
     @Autowired
     public TravelogueControllerTest(
@@ -66,7 +66,7 @@ class TravelogueControllerTest {
     @Test
     void createTravelogue() {
         Mockito.when(s3Provider.copyImageToPermanentStorage(any(String.class)))
-                .thenReturn("imageUrl.png");
+                .thenReturn(TravelogueResponseFixture.getTravelogueResponse().thumbnail());
 
         TravelogueRequest request = TravelogueRequestFixture.getTravelogueRequest();
         Member member = testHelper.initMemberTestData();

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -1,7 +1,7 @@
 package kr.touroot.travelogue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import kr.touroot.global.ServiceTest;
 import kr.touroot.global.auth.dto.MemberAuth;
@@ -16,7 +16,6 @@ import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -64,8 +63,12 @@ class TravelogueFacadeServiceTest {
     @DisplayName("여행기를 생성할 수 있다.")
     @Test
     void createTravelogue() {
-        Mockito.when(s3Provider.copyImageToPermanentStorage(any(String.class)))
-                .thenReturn(TravelogueResponseFixture.getTraveloguePhotoUrls().get(0));
+        when(s3Provider.copyImageToPermanentStorage(
+                TravelogueRequestFixture.getTravelogueRequest().thumbnail())
+        ).thenReturn(TravelogueResponseFixture.getTravelogueResponse().thumbnail());
+        when(s3Provider.copyImageToPermanentStorage(
+                TravelogueRequestFixture.getTraveloguePhotoRequests().get(0).url())
+        ).thenReturn(TravelogueResponseFixture.getTraveloguePhotoUrls().get(0));
 
         testHelper.initMemberTestData();
 


### PR DESCRIPTION
# ✅ 작업 내용

- 썸네일 저장 시 S3의 영구 이미지 폴더로 복사 기능 구현
- url 파싱 오류 수정