### PR TITLE
[Feature] - 로그인 명세 수정

### DIFF
--- a/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
+++ b/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
@@ -37,8 +37,11 @@ public class LoginController {
             )
     })
     @GetMapping("/oauth/kakao")
-    public ResponseEntity<LoginResponse> login(@RequestParam(name = "code") String authorizationCode) {
+    public ResponseEntity<LoginResponse> login(
+            @RequestParam(name = "code") String authorizationCode,
+            @RequestParam(name = "redirectUri", defaultValue = "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fv1%2Flogin%2Foauth%2Fkakao") String encodedRedirectUri
+    ) {
         return ResponseEntity.ok()
-                .body(loginService.login(authorizationCode));
+                .body(loginService.login(authorizationCode, encodedRedirectUri));
     }
 }

--- a/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
+++ b/backend/src/main/java/kr/touroot/authentication/controller/LoginController.java
@@ -11,7 +11,7 @@ import kr.touroot.authentication.service.LoginService;
 import kr.touroot.global.exception.dto.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,10 +36,10 @@ public class LoginController {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    @GetMapping("/oauth/kakao")
+    @PostMapping("/oauth/kakao")
     public ResponseEntity<LoginResponse> login(
             @RequestParam(name = "code") String authorizationCode,
-            @RequestParam(name = "redirectUri", defaultValue = "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fv1%2Flogin%2Foauth%2Fkakao") String encodedRedirectUri
+            @RequestParam(name = "redirectUri") String encodedRedirectUri
     ) {
         return ResponseEntity.ok()
                 .body(loginService.login(authorizationCode, encodedRedirectUri));

--- a/backend/src/main/java/kr/touroot/authentication/infrastructure/KakaoOauthClient.java
+++ b/backend/src/main/java/kr/touroot/authentication/infrastructure/KakaoOauthClient.java
@@ -26,19 +26,16 @@ public class KakaoOauthClient {
     private final String userInformationRequestUri;
     private final String accessTokenRequestUri;
     private final String restApiKey;
-    private final String redirectUri;
     private final RestClient restClient;
 
     public KakaoOauthClient(
             @Value("${oauth.kakao.user-information-request-uri}") String userInformationRequestUri,
             @Value("${oauth.kakao.access-token-request-uri}") String accessTokenRequestUri,
-            @Value("${oauth.kakao.rest-api-key}") String restApiKey,
-            @Value("${oauth.kakao.redirect-uri}") String redirectUri
+            @Value("${oauth.kakao.rest-api-key}") String restApiKey
     ) {
         this.userInformationRequestUri = userInformationRequestUri;
         this.accessTokenRequestUri = accessTokenRequestUri;
         this.restApiKey = restApiKey;
-        this.redirectUri = redirectUri;
         this.restClient = buildRestClient();
     }
 
@@ -54,8 +51,8 @@ public class KakaoOauthClient {
                 .build();
     }
 
-    public OauthUserInformationResponse requestUserInformation(String authorizationCode) {
-        KakaoAccessTokenResponse kakaoAccessTokenResponse = requestAccessToken(authorizationCode);
+    public OauthUserInformationResponse requestUserInformation(String authorizationCode, String redirectUri) {
+        KakaoAccessTokenResponse kakaoAccessTokenResponse = requestAccessToken(authorizationCode, redirectUri);
 
         return restClient.get()
                 .uri(userInformationRequestUri)
@@ -66,7 +63,7 @@ public class KakaoOauthClient {
                 .getBody();
     }
 
-    private KakaoAccessTokenResponse requestAccessToken(String authorizationCode) {
+    private KakaoAccessTokenResponse requestAccessToken(String authorizationCode, String redirectUri) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", authorizationCode);
         params.add("client_id", restApiKey);

--- a/backend/src/main/java/kr/touroot/authentication/infrastructure/KakaoOauthProvider.java
+++ b/backend/src/main/java/kr/touroot/authentication/infrastructure/KakaoOauthProvider.java
@@ -1,8 +1,8 @@
 package kr.touroot.authentication.infrastructure;
 
+import kr.touroot.authentication.dto.response.OauthUserInformationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import kr.touroot.authentication.dto.response.OauthUserInformationResponse;
 
 @RequiredArgsConstructor
 @Component
@@ -10,7 +10,7 @@ public class KakaoOauthProvider {
 
     private final KakaoOauthClient kakaoOauthClient;
 
-    public OauthUserInformationResponse getUserInformation(String authorizationCode) {
-        return kakaoOauthClient.requestUserInformation(authorizationCode);
+    public OauthUserInformationResponse getUserInformation(String authorizationCode, String redirectUri) {
+        return kakaoOauthClient.requestUserInformation(authorizationCode, redirectUri);
     }
 }

--- a/backend/src/main/java/kr/touroot/authentication/service/LoginService.java
+++ b/backend/src/main/java/kr/touroot/authentication/service/LoginService.java
@@ -1,5 +1,7 @@
 package kr.touroot.authentication.service;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import kr.touroot.authentication.dto.response.LoginResponse;
 import kr.touroot.authentication.dto.response.OauthUserInformationResponse;
 import kr.touroot.authentication.infrastructure.JwtTokenProvider;
@@ -17,8 +19,9 @@ public class LoginService {
     private final KakaoOauthProvider oauthProvider;
     private final JwtTokenProvider tokenProvider;
 
-    public LoginResponse login(String code) {
-        OauthUserInformationResponse userInformation = oauthProvider.getUserInformation(code);
+    public LoginResponse login(String code, String encodedRedirectUri) {
+        String redirectUri = URLDecoder.decode(encodedRedirectUri, StandardCharsets.UTF_8);
+        OauthUserInformationResponse userInformation = oauthProvider.getUserInformation(code, redirectUri);
         Member member = memberRepository.findByKakaoId(userInformation.socialLoginId())
                 .orElseGet(() -> signUp(userInformation));
 

--- a/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             new HttpRequestInfo(HttpMethod.GET, "/swagger-resources/**"),
             new HttpRequestInfo(HttpMethod.GET, "/v3/api-docs/**"),
             new HttpRequestInfo(HttpMethod.GET, "/api/v1/travelogues/**"),
-            new HttpRequestInfo(HttpMethod.GET, "/api/v1/login/**"),
+            new HttpRequestInfo(HttpMethod.POST, "/api/v1/login/**"),
             new HttpRequestInfo(HttpMethod.GET, "/api/v1/travel-plans/shared/**"),
             new HttpRequestInfo(HttpMethod.OPTIONS, "/**")
     );

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,7 +3,6 @@ oauth:
     user-information-request-uri: https://kapi.kakao.com/v2/user/me
     access-token-request-uri: https://kauth.kakao.com/oauth/token
     rest-api-key: ENC(i6J7NWUsDpXVbJrbSUcNFI3h0oc6v8PxuHShU9UA7EVuUNLtQN/ANII+8j5HjhGO)
-    redirect-uri: http://localhost:3000/oauth
 jasypt:
   encryptor:
     algorithm: PBEWithMD5AndDES
@@ -22,9 +21,6 @@ security:
     token:
       secret-key: ENC(SNwFG2NQDZkmIK3nNoZFdwQ0ZxKuoe+qcw10ljdW941YEx/Qky9PEEl+wvAN9S1KR26D3a83SnU=)
       expire-length: 1800000
-oauth:
-  kakao:
-    redirect-uri: http://localhost:8080/api/v1/login/oauth/kakao
 spring:
   config:
     activate:

--- a/backend/src/test/java/kr/touroot/authentication/controller/LoginControllerTest.java
+++ b/backend/src/test/java/kr/touroot/authentication/controller/LoginControllerTest.java
@@ -2,7 +2,7 @@ package kr.touroot.authentication.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -42,8 +42,9 @@ class LoginControllerTest {
         LoginResponse loginResponse = new LoginResponse("리비", "img-url", "test-access-token");
         when(loginService.login(any(String.class), any(String.class))).thenReturn(loginResponse);
 
-        mockMvc.perform(get("/api/v1/login/oauth/kakao")
-                        .param("code", "test-authorization-code"))
+        mockMvc.perform(post("/api/v1/login/oauth/kakao")
+                        .param("code", "test-authorization-code")
+                        .param("redirectUri", "https://touroot.kr/oauth"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(objectMapper.writeValueAsString(loginResponse)));

--- a/backend/src/test/java/kr/touroot/authentication/controller/LoginControllerTest.java
+++ b/backend/src/test/java/kr/touroot/authentication/controller/LoginControllerTest.java
@@ -40,7 +40,7 @@ class LoginControllerTest {
     @Test
     void loginTest() throws Exception {
         LoginResponse loginResponse = new LoginResponse("리비", "img-url", "test-access-token");
-        when(loginService.login(any(String.class))).thenReturn(loginResponse);
+        when(loginService.login(any(String.class), any(String.class))).thenReturn(loginResponse);
 
         mockMvc.perform(get("/api/v1/login/oauth/kakao")
                         .param("code", "test-authorization-code"))

--- a/backend/src/test/java/kr/touroot/authentication/service/LoginServiceTest.java
+++ b/backend/src/test/java/kr/touroot/authentication/service/LoginServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LoginServiceTest {
 
     private static final String AUTHENTICATION_CODE = "test-authentication-code";
+    private static final String REDIRECT_URI = "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fv1%2Flogin%2Foauth%2Fkakao";
 
     @InjectMocks
     private LoginService loginService;
@@ -40,11 +41,11 @@ class LoginServiceTest {
     @Test
     void existUserKakaoSocialLoginTest() {
         // given
-        when(kakaoOauthProvider.getUserInformation(AUTHENTICATION_CODE))
+        when(kakaoOauthProvider.getUserInformation(any(String.class), any(String.class)))
                 .thenReturn(OauthUserInformationFixture.USER_1_OAUTH_INFORMATION);
         when(memberRepository.findByKakaoId(any(Long.class)))
                 .thenReturn(Optional.of(MemberFixture.MEMBER_1));
-        LoginResponse response = loginService.login(AUTHENTICATION_CODE);
+        LoginResponse response = loginService.login(AUTHENTICATION_CODE, REDIRECT_URI);
 
         // when & then
         assertThat(response).isEqualTo(
@@ -55,13 +56,13 @@ class LoginServiceTest {
     @Test
     void nonExistUserKakaoSocialLoginTest() {
         // given
-        when(kakaoOauthProvider.getUserInformation(AUTHENTICATION_CODE))
+        when(kakaoOauthProvider.getUserInformation(any(String.class), any(String.class)))
                 .thenReturn(OauthUserInformationFixture.USER_1_OAUTH_INFORMATION);
         when(memberRepository.findByKakaoId(any(Long.class)))
                 .thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class)))
                 .thenReturn(MemberFixture.MEMBER_1);
-        LoginResponse response = loginService.login(AUTHENTICATION_CODE);
+        LoginResponse response = loginService.login(AUTHENTICATION_CODE, REDIRECT_URI);
 
         // when & then
         assertThat(response).isEqualTo(


### PR DESCRIPTION
# ✅ 작업 내용

- 쿼리파라미터로 인코딩된 redirectUri를 받도록 수정

# 🙈 참고 사항
- 쿼리파라미터의 디폴트 값을 활용하여 백엔드 로컬에서도 지금까지와 동일한 방식으로 로그인을 테스트 할 수 있습니다.
- 다만 로그인 같은 경우 현재 저희의 로직이라면 HTTP METHOD post가 맞는 것 같습니다.
- 백엔드 로컬에서의 로그인 확인을 포기하고 post로 명세를 수정하는 것이 좋을 지 현행처럼 get으로 둘지 고민이에요
- 의견 주시면 감사링