### PR TITLE
[Fix] - 여행 전환 후 다른 페이지에서 다시 등록 페이지로 접근 시 데이터가 남아있는 문제 해결

### DIFF
--- a/frontend/src/components/pages/travelPlanRegister/TravelPlanRegisterPage.tsx
+++ b/frontend/src/components/pages/travelPlanRegister/TravelPlanRegisterPage.tsx
@@ -28,7 +28,7 @@ import * as S from "./TravelPlanRegisterPage.styled";
 const MAX_TITLE_LENGTH = 20;
 
 const TravelPlanRegisterPage = () => {
-  const { transformDetail } = useTravelTransformDetailContext();
+  const { transformDetail, saveTransformDetail } = useTravelTransformDetailContext();
 
   const [title, setTitle] = useState("");
   const [startDate, setStartDate] = useState<Date | null>(null);
@@ -101,7 +101,10 @@ const TravelPlanRegisterPage = () => {
       alert(ERROR_MESSAGE_MAP.api.login);
       navigate(ROUTE_PATHS_MAP.login);
     }
-  }, [user?.accessToken, navigate]);
+    return () => {
+      saveTransformDetail(null);
+    };
+  }, [user?.accessToken, navigate, saveTransformDetail]);
 
   return (
     <>

--- a/frontend/src/components/pages/travelogueDetail/TravelogueDetailPage.tsx
+++ b/frontend/src/components/pages/travelogueDetail/TravelogueDetailPage.tsx
@@ -56,7 +56,7 @@ const TravelogueDetailPage = () => {
         )}
       />
       <TransformBottomSheet
-        onTransform={() => onTransformTravelDetail("/travel-plans/register", data)}
+        onTransform={() => onTransformTravelDetail("/travel-plan/register", data)}
         buttonLabel="여행 계획으로 전환"
       >
         이 여행기를 따라가고 싶으신가요?

--- a/frontend/src/components/pages/travelogueRegister/TravelogueRegisterPage.tsx
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueRegisterPage.tsx
@@ -91,11 +91,17 @@ const TravelogueRegisterPage = () => {
 
   const { user } = useUser();
 
+  const { saveTransformDetail } = useTravelTransformDetailContext();
+
   useEffect(() => {
     if (!user?.accessToken) {
       alert(ERROR_MESSAGE_MAP.api.login);
       navigate(ROUTE_PATHS_MAP.login);
     }
+
+    return () => {
+      saveTransformDetail(null);
+    };
   }, [user?.accessToken, navigate]);
 
   return (

--- a/frontend/src/contexts/TravelTransformDetailProvider.tsx
+++ b/frontend/src/contexts/TravelTransformDetailProvider.tsx
@@ -11,14 +11,16 @@ import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
 import { ROUTE_PATHS_MAP } from "@constants/route";
 
 const TravelogueContext = createContext<TravelTransformDetail | null>(null);
-const SaveTravelogueContext = createContext<(travelogue: TravelTransformDetail) => void>(() => {});
+const SaveTravelogueContext = createContext<(travelogue: TravelTransformDetail | null) => void>(
+  () => {},
+);
 
 export const TravelTransformDetailProvider = ({ children }: React.PropsWithChildren) => {
   const [travelTransformDetail, setTravelTransformDetail] = useState<TravelTransformDetail | null>(
     null,
   );
 
-  const saveTravelTransformDetail = (transformDetail: TravelTransformDetail) => {
+  const saveTravelTransformDetail = (transformDetail: TravelTransformDetail | null) => {
     setTravelTransformDetail(transformDetail);
   };
 
@@ -51,5 +53,5 @@ export const useTravelTransformDetailContext = () => {
     }
   };
 
-  return { transformDetail, onTransformTravelDetail };
+  return { transformDetail, saveTransformDetail, onTransformTravelDetail };
 };


### PR DESCRIPTION
# ✅ 작업 내용
- 페이지를 벗어나면 transformDetail를 null로 변경

# 📸 스크린샷
## 여행 계획 - 여행기 전환
https://github.com/user-attachments/assets/c6952701-d5ea-4954-a2b2-00a313274cb2

## 여행기 - 여행 계획 전환
https://github.com/user-attachments/assets/8261e313-3d2c-4fca-9a12-92c631455586

# 🙈 참고 사항
x