### PR TITLE
[Feature] - user 컨텍스트에 access token만 담도록 수정 & 로그인/로그아웃 버튼 수정

### DIFF
--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -15,6 +15,7 @@ import Drawer from "../Drawer/Drawer";
 import * as S from "./Header.styled";
 
 const Header = () => {
+  const { user, saveUser } = useUser();
   const location = useLocation();
   const pathName = location.pathname;
 
@@ -61,9 +62,8 @@ const Header = () => {
             <S.MenuItem>마이페이지</S.MenuItem>
           </Drawer.Trigger>
           <Drawer.Trigger>
-            {user ? (
-              //TODO: 로그아웃 로직 필요함
-              <S.MenuItem>로그아웃</S.MenuItem>
+            {user?.accessToken ? (
+              <S.MenuItem onClick={handleClickLogout}>로그아웃</S.MenuItem>
             ) : (
               <S.MenuItem
                 onClick={() => {

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -26,7 +26,9 @@ const Header = () => {
       ? () => navigate(ROUTE_PATHS_MAP.root)
       : () => navigate(ROUTE_PATHS_MAP.back);
 
-  const { user } = useUser();
+  const handleClickLogout = () => {
+    saveUser({ accessToken: "" });
+  };
 
   return (
     <Drawer>

--- a/frontend/src/components/pages/login/KakaoCallbackPage.tsx
+++ b/frontend/src/components/pages/login/KakaoCallbackPage.tsx
@@ -21,7 +21,7 @@ const KakaoCallbackPage = () => {
       client
         .get(API_ENDPOINT_MAP.loginOauth(code))
         .then((res) => {
-          saveUser(res.data);
+          saveUser({ accessToken: res.data.accessToken });
           navigate(ROUTE_PATHS_MAP.root);
         })
         .catch(() => {

--- a/frontend/src/constants/endpoint.ts
+++ b/frontend/src/constants/endpoint.ts
@@ -5,4 +5,5 @@ export const API_ENDPOINT_MAP = {
   travelogues: "/travelogues",
   travelPlans: "/travel-plans",
   image: "/image",
+  profile: "member/me/profile",
 } as const;

--- a/frontend/src/constants/queryKey.ts
+++ b/frontend/src/constants/queryKey.ts
@@ -7,4 +7,8 @@ export const QUERY_KEYS_MAP = {
     all: ["travel-plans"],
     detail: (id: string) => [...QUERY_KEYS_MAP.travelPlan.all, id],
   },
+  member: {
+    all: ["member"],
+    me: () => [...QUERY_KEYS_MAP.member.all, "me"],
+  },
 };

--- a/frontend/src/contexts/UserProvider.tsx
+++ b/frontend/src/contexts/UserProvider.tsx
@@ -1,26 +1,26 @@
 import { createContext, useState } from "react";
 
-import type { UserResponse } from "@type/domain/user";
+import type { AuthTokenResponse } from "@type/domain/user";
 
 import { STORAGE_KEYS_MAP } from "@constants/storage";
 
 export interface UserContextProps {
-  user: UserResponse | null;
+  user: AuthTokenResponse | null;
 }
 
 export interface SaveUserContextProps {
-  saveUser: (userInfo: UserResponse) => void;
+  saveUser: (userInfo: AuthTokenResponse) => void;
 }
 
 export const UserContext = createContext({} as UserContextProps);
 export const SaveUserContext = createContext({} as SaveUserContextProps);
 
 const UserProvider = ({ children }: React.PropsWithChildren) => {
-  const [user, setUser] = useState<UserResponse | null>(
+  const [user, setUser] = useState<AuthTokenResponse | null>(
     () => JSON.parse(localStorage.getItem(STORAGE_KEYS_MAP.user) ?? "{}") ?? null,
   );
 
-  const saveUser = (user: UserResponse) => {
+  const saveUser = (user: AuthTokenResponse) => {
     localStorage.setItem(STORAGE_KEYS_MAP.user, JSON.stringify(user ?? {}));
     setUser(user);
   };

--- a/frontend/src/queries/useUserProfile.ts
+++ b/frontend/src/queries/useUserProfile.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { UserResponse } from "@type/domain/user";
+
+import { authClient } from "@apis/client";
+
+import { API_ENDPOINT_MAP } from "@constants/endpoint";
+import { QUERY_KEYS_MAP } from "@constants/queryKey";
+
+export const useUserProfile = () => {
+  return useQuery<UserResponse>({
+    queryKey: QUERY_KEYS_MAP.member.me(),
+    queryFn: async () => {
+      const { data } = await authClient.get(API_ENDPOINT_MAP.profile);
+
+      return data;
+    },
+  });
+};

--- a/frontend/src/types/domain/user.ts
+++ b/frontend/src/types/domain/user.ts
@@ -1,5 +1,8 @@
-export interface UserResponse {
+export interface AuthTokenResponse {
   accessToken: string;
+}
+
+export interface UserResponse extends AuthTokenResponse {
   nickname: string;
   profileImageUrl: string;
 }


### PR DESCRIPTION
# ✅ 작업 내용

- user 컨텍스트에 access token만 담는다.
- `nickname`, `profileImageUrl`은 api에서 가져온다.
- Drawer에서 로그인/로그아웃 버튼 로그아웃으로만 나오는 이슈 수정한다.
- 로그아웃 구현


# 📸 스크린샷

# 🙈 참고 사항

- 로그아웃은 로컬스토리지에서 accessToken 지우는것으로 일단 구현해놨습니다
