### PR TITLE
[Feature] - 삭제 API 구현

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -106,7 +106,7 @@ public class TravelogueController {
                     description = "요청이 정상적으로 처리되었을 때"
             ),
             @ApiResponse(
-                    responseCode = "404",
+                    responseCode = "400",
                     description = "존재하지 않는 여행기 ID로 요청했을 때",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             ),

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -110,10 +110,15 @@ public class TravelogueController {
                     description = "존재하지 않는 여행기 ID로 요청했을 때",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "작성자가 아닌 사용자가 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
     })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteTravelogue(@PathVariable Long id) {
-        travelogueFacadeService.deleteTravelogueById(id);
+    public ResponseEntity<Void> deleteTravelogue(@PathVariable Long id, MemberAuth memberAuth) {
+        travelogueFacadeService.deleteTravelogueById(id, memberAuth);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -96,5 +97,24 @@ public class TravelogueController {
             Pageable pageable
     ) {
         return ResponseEntity.ok(travelogueFacadeService.findTravelogues(pageable));
+    }
+
+    @Operation(summary = "여행기 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 여행기 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTravelogue(@PathVariable Long id) {
+        travelogueFacadeService.deleteTravelogueById(id);
+        return ResponseEntity.noContent()
+                .build();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -16,10 +16,14 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travelogue SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class Travelogue extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.net.URL;
+import java.util.Objects;
 import kr.touroot.global.entity.BaseEntity;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.member.domain.Member;
@@ -87,5 +88,9 @@ public class Travelogue extends BaseEntity {
         } catch (Exception e) {
             throw new BadRequestException("이미지 url 형식이 잘못되었습니다");
         }
+    }
+
+    public boolean isAuthor(Member author) {
+        return Objects.equals(author.getId(), this.author.getId());
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueDay.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueDay.java
@@ -14,10 +14,14 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travelogue_day SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class TravelogueDay extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelogue/domain/TraveloguePhoto.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TraveloguePhoto.java
@@ -14,10 +14,14 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travelogue_photo SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class TraveloguePhoto extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelogue/domain/TraveloguePlace.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TraveloguePlace.java
@@ -15,10 +15,14 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travelogue_place SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class TraveloguePlace extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueDayRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueDayRepository.java
@@ -9,5 +9,5 @@ public interface TravelogueDayRepository extends JpaRepository<TravelogueDay, Lo
 
     List<TravelogueDay> findByTravelogue(Travelogue travelogue);
 
-    void deleteByTravelogueId(Long travelogueId);
+    void deleteByTravelogue(Travelogue travelogue);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueDayRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueDayRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TravelogueDayRepository extends JpaRepository<TravelogueDay, Long> {
 
     List<TravelogueDay> findByTravelogue(Travelogue travelogue);
+
+    void deleteByTravelogueId(Long travelogueId);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePhotoRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePhotoRepository.java
@@ -1,11 +1,13 @@
 package kr.touroot.travelogue.repository;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import kr.touroot.travelogue.domain.TraveloguePhoto;
 import kr.touroot.travelogue.domain.TraveloguePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TraveloguePhotoRepository extends JpaRepository<TraveloguePhoto, Long> {
 
     List<TraveloguePhoto> findByTraveloguePlace(TraveloguePlace traveloguePlace);
+
+    void deleteByTraveloguePlaceTravelogueDayTravelogueId(Long travelogueId);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePhotoRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePhotoRepository.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelogue.repository;
 
 import java.util.List;
+import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TraveloguePhoto;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,5 @@ public interface TraveloguePhotoRepository extends JpaRepository<TraveloguePhoto
 
     List<TraveloguePhoto> findByTraveloguePlace(TraveloguePlace traveloguePlace);
 
-    void deleteByTraveloguePlaceTravelogueDayTravelogueId(Long travelogueId);
+    void deleteByTraveloguePlaceTravelogueDayTravelogue(Travelogue travelogue);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePlaceRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePlaceRepository.java
@@ -1,11 +1,13 @@
 package kr.touroot.travelogue.repository;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import kr.touroot.travelogue.domain.TravelogueDay;
 import kr.touroot.travelogue.domain.TraveloguePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TraveloguePlaceRepository extends JpaRepository<TraveloguePlace, Long> {
 
     List<TraveloguePlace> findByTravelogueDay(TravelogueDay travelogueDay);
+
+    void deleteByTravelogueDayTravelogueId(Long travelogueId);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePlaceRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePlaceRepository.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelogue.repository;
 
 import java.util.List;
+import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueDay;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,5 @@ public interface TraveloguePlaceRepository extends JpaRepository<TraveloguePlace
 
     List<TraveloguePlace> findByTravelogueDay(TravelogueDay travelogueDay);
 
-    void deleteByTravelogueDayTravelogueId(Long travelogueId);
+    void deleteByTravelogueDayTravelogue(Travelogue travelogue);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueDayService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueDayService.java
@@ -44,7 +44,7 @@ public class TravelogueDayService {
     }
 
     @Transactional
-    public void deleteByTravelogueId(Long travelogueId) {
-        travelogueDayRepository.deleteByTravelogueId(travelogueId);
+    public void deleteByTravelogue(Travelogue travelogue) {
+        travelogueDayRepository.deleteByTravelogue(travelogue);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueDayService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueDayService.java
@@ -11,6 +11,7 @@ import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.repository.TravelogueDayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -40,5 +41,10 @@ public class TravelogueDayService {
     public TravelogueDay findDayById(Long id) {
         return travelogueDayRepository.findById(id)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행기 일자입니다."));
+    }
+
+    @Transactional
+    public void deleteByTravelogueId(Long travelogueId) {
+        travelogueDayRepository.deleteByTravelogueId(travelogueId);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -107,10 +107,14 @@ public class TravelogueFacadeService {
     }
 
     @Transactional
-    public void deleteTravelogueById(Long id) {
-        traveloguePhotoService.deleteByTravelogueId(id);
-        traveloguePlaceService.deleteByTravelogueId(id);
-        travelogueDayService.deleteByTravelogueId(id);
-        travelogueService.deleteById(id);
+    public void deleteTravelogueById(Long id, MemberAuth member) {
+        Member author = memberService.getById(member.memberId());
+        Travelogue travelogue = travelogueService.getTravelogueById(id);
+        travelogueService.validateAuthor(travelogue, author);
+
+        traveloguePhotoService.deleteByTravelogue(travelogue);
+        traveloguePlaceService.deleteByTravelogue(travelogue);
+        travelogueDayService.deleteByTravelogue(travelogue);
+        travelogueService.delete(travelogue, author);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -110,7 +110,7 @@ public class TravelogueFacadeService {
     public void deleteTravelogueById(Long id, MemberAuth member) {
         Member author = memberService.getById(member.memberId());
         Travelogue travelogue = travelogueService.getTravelogueById(id);
-        travelogueService.validateAuthor(travelogue, author);
+        travelogueService.validateDeleteByAuthor(travelogue, author);
 
         traveloguePhotoService.deleteByTravelogue(travelogue);
         traveloguePlaceService.deleteByTravelogue(travelogue);

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -105,4 +105,12 @@ public class TravelogueFacadeService {
     private List<String> findPhotoUrlsOfTraveloguePlace(TraveloguePlace place) {
         return traveloguePhotoService.findPhotoUrlsByPlace(place);
     }
+
+    @Transactional
+    public void deleteTravelogueById(Long id) {
+        traveloguePhotoService.deleteByTravelogueId(id);
+        traveloguePlaceService.deleteByTravelogueId(id);
+        travelogueDayService.deleteByTravelogueId(id);
+        travelogueService.deleteById(id);
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
@@ -10,7 +10,7 @@ import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.repository.TraveloguePhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -39,5 +39,10 @@ public class TraveloguePhotoService {
                 .sorted(Comparator.comparing(TraveloguePhoto::getOrder))
                 .map(TraveloguePhoto::getKey)
                 .toList();
+    }
+
+    @Transactional
+    public void deleteByTravelogueId(Long travelogueId) {
+        traveloguePhotoRepository.deleteByTraveloguePlaceTravelogueDayTravelogueId(travelogueId);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import kr.touroot.image.infrastructure.AwsS3Provider;
+import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TraveloguePhoto;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
@@ -42,7 +43,7 @@ public class TraveloguePhotoService {
     }
 
     @Transactional
-    public void deleteByTravelogueId(Long travelogueId) {
-        traveloguePhotoRepository.deleteByTraveloguePlaceTravelogueDayTravelogueId(travelogueId);
+    public void deleteByTravelogue(Travelogue travelogue) {
+        traveloguePhotoRepository.deleteByTraveloguePlaceTravelogueDayTravelogue(travelogue);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePlaceService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePlaceService.java
@@ -13,6 +13,7 @@ import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.repository.TraveloguePlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -53,5 +54,10 @@ public class TraveloguePlaceService {
     public TraveloguePlace findTraveloguePlaceById(Long id) {
         return traveloguePlaceRepository.findById(id)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행기 장소입니다."));
+    }
+
+    @Transactional
+    public void deleteByTravelogueId(Long travelogueId) {
+        traveloguePlaceRepository.deleteByTravelogueDayTravelogueId(travelogueId);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePlaceService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePlaceService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.place.domain.Place;
 import kr.touroot.place.repository.PlaceRepository;
+import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueDay;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
@@ -57,7 +58,7 @@ public class TraveloguePlaceService {
     }
 
     @Transactional
-    public void deleteByTravelogueId(Long travelogueId) {
-        traveloguePlaceRepository.deleteByTravelogueDayTravelogueId(travelogueId);
+    public void deleteByTravelogue(Travelogue travelogue) {
+        traveloguePlaceRepository.deleteByTravelogueDayTravelogue(travelogue);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -36,4 +36,8 @@ public class TravelogueService {
     public Page<Travelogue> findAllByMember(Member member, Pageable pageable) {
         return travelogueRepository.findAllByAuthor(member, pageable);
     }
+
+    public void deleteById(Long id) {
+        travelogueRepository.deleteById(id);
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -39,13 +39,13 @@ public class TravelogueService {
     }
 
     public void delete(Travelogue travelogue, Member author) {
-        validateAuthor(travelogue, author);
+        validateDeleteByAuthor(travelogue, author);
         travelogueRepository.delete(travelogue);
     }
 
-    public void validateAuthor(Travelogue travelogue, Member author) {
+    public void validateDeleteByAuthor(Travelogue travelogue, Member author) {
         if (!travelogue.isAuthor(author)) {
-            throw new ForbiddenException("작성자만 가능합니다.");
+            throw new ForbiddenException("여행기 삭제는 작성자만 가능합니다.");
         }
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelogue.service;
 
 import kr.touroot.global.exception.BadRequestException;
+import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
@@ -37,11 +38,14 @@ public class TravelogueService {
         return travelogueRepository.findAllByAuthor(member, pageable);
     }
 
-    public void deleteById(Long id) {
-        if (!travelogueRepository.existsById(id)) {
-            throw new BadRequestException("존재하지 않는 여행기입니다.");
-        }
+    public void delete(Travelogue travelogue, Member author) {
+        validateAuthor(travelogue, author);
+        travelogueRepository.delete(travelogue);
+    }
 
-        travelogueRepository.deleteById(id);
+    public void validateAuthor(Travelogue travelogue, Member author) {
+        if (!travelogue.isAuthor(author)) {
+            throw new ForbiddenException("작성자만 가능합니다.");
+        }
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -38,6 +38,10 @@ public class TravelogueService {
     }
 
     public void deleteById(Long id) {
+        if (!travelogueRepository.existsById(id)) {
+            throw new BadRequestException("존재하지 않는 여행기입니다.");
+        }
+
         travelogueRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -93,7 +93,7 @@ public class TravelPlanController {
                     description = "요청이 정상적으로 처리되었을 때"
             ),
             @ApiResponse(
-                    responseCode = "404",
+                    responseCode = "400",
                     description = "존재하지 않는 여행 계획 ID로 요청했을 때",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             ),

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.net.URI;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.dto.ExceptionResponse;
 import kr.touroot.travelplan.dto.request.TravelPlanCreateRequest;
@@ -16,9 +17,13 @@ import kr.touroot.travelplan.dto.response.TravelPlanResponse;
 import kr.touroot.travelplan.service.TravelPlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "여행 계획")
 @RequiredArgsConstructor
@@ -79,5 +84,24 @@ public class TravelPlanController {
     ) {
         TravelPlanResponse data = travelPlanService.readTravelPlan(id, memberAuth);
         return ResponseEntity.ok(data);
+    }
+
+    @Operation(summary = "여행 계획 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 여행 계획 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTravelPlan(@PathVariable Long id) {
+        travelPlanService.deleteByTravelPlanId(id);
+        return ResponseEntity.noContent()
+                .build();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -97,10 +97,15 @@ public class TravelPlanController {
                     description = "존재하지 않는 여행 계획 ID로 요청했을 때",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "작성자가 아닌 사용자가 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
     })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteTravelPlan(@PathVariable Long id) {
-        travelPlanService.deleteByTravelPlanId(id);
+    public ResponseEntity<Void> deleteTravelPlan(@PathVariable Long id, MemberAuth memberAuth) {
+        travelPlanService.deleteByTravelPlanId(id, memberAuth);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
@@ -15,9 +15,13 @@ import kr.touroot.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travel_plan SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class TravelPlan extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
@@ -14,9 +14,13 @@ import kr.touroot.global.exception.BadRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travel_plan_day SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class TravelPlanDay extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
@@ -14,9 +14,13 @@ import kr.touroot.place.domain.Place;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travel_plan_place SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class TravelPlanPlace extends BaseEntity {
 

--- a/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanDayRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanDayRepository.java
@@ -9,5 +9,5 @@ public interface TravelPlanDayRepository extends JpaRepository<TravelPlanDay, Lo
 
     List<TravelPlanDay> findByPlan(TravelPlan travelPlan);
 
-    void deleteByPlanId(Long planId);
+    void deleteByPlan(TravelPlan plan);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanDayRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanDayRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TravelPlanDayRepository extends JpaRepository<TravelPlanDay, Long> {
 
     List<TravelPlanDay> findByPlan(TravelPlan travelPlan);
+
+    void deleteByPlanId(Long planId);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanPlaceRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanPlaceRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TravelPlanPlaceRepository extends JpaRepository<TravelPlanPlace, Long> {
 
     List<TravelPlanPlace> findByDay(TravelPlanDay day);
+
+    void deleteByDayPlanId(Long planId);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanPlaceRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanPlaceRepository.java
@@ -1,6 +1,7 @@
 package kr.touroot.travelplan.repository;
 
 import java.util.List;
+import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.domain.TravelPlanDay;
 import kr.touroot.travelplan.domain.TravelPlanPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,5 @@ public interface TravelPlanPlaceRepository extends JpaRepository<TravelPlanPlace
 
     List<TravelPlanPlace> findByDay(TravelPlanDay day);
 
-    void deleteByDayPlanId(Long planId);
+    void deleteByDayPlan(TravelPlan plan);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -134,12 +134,10 @@ public class TravelPlanService {
 
     @Transactional
     public void deleteByTravelPlanId(Long planId) {
-        if (!travelPlanRepository.existsById(planId)) {
-            throw new BadRequestException("존재하지 않는 여행 계획입니다.");
-        }
+        TravelPlan travelPlan = getTravelPlanById(planId);
 
-        travelPlanPlaceRepository.deleteByDayPlanId(planId);
-        travelPlanDayRepository.deleteByPlanId(planId);
-        travelPlanRepository.deleteById(planId);
+        travelPlanPlaceRepository.deleteByDayPlan(travelPlan);
+        travelPlanDayRepository.deleteByPlan(travelPlan);
+        travelPlanRepository.delete(travelPlan);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -96,7 +96,7 @@ public class TravelPlanService {
 
     private void validateAuthor(TravelPlan travelPlan, Member member) {
         if (!travelPlan.isAuthor(member)) {
-            throw new ForbiddenException("여행 계획은 작성자만 조회할 수 있습니다.");
+            throw new ForbiddenException("작성자만 가능합니다.");
         }
     }
 
@@ -133,8 +133,10 @@ public class TravelPlanService {
     }
 
     @Transactional
-    public void deleteByTravelPlanId(Long planId) {
+    public void deleteByTravelPlanId(Long planId, MemberAuth memberAuth) {
         TravelPlan travelPlan = getTravelPlanById(planId);
+        Member author = getMemberByMemberAuth(memberAuth);
+        validateAuthor(travelPlan, author);
 
         travelPlanPlaceRepository.deleteByDayPlan(travelPlan);
         travelPlanDayRepository.deleteByPlan(travelPlan);

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -1,5 +1,7 @@
 package kr.touroot.travelplan.service;
 
+import java.util.Comparator;
+import java.util.List;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
@@ -25,9 +27,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Comparator;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -131,5 +130,12 @@ public class TravelPlanService {
     public int calculateTravelPeriod(TravelPlan travelPlan) {
         return travelPlanDayRepository.findByPlan(travelPlan)
                 .size();
+    }
+
+    @Transactional
+    public void deleteByTravelPlanId(Long planId) {
+        travelPlanPlaceRepository.deleteByDayPlanId(planId);
+        travelPlanDayRepository.deleteByPlanId(planId);
+        travelPlanRepository.deleteById(planId);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -90,14 +90,14 @@ public class TravelPlanService {
     public TravelPlanResponse readTravelPlan(Long planId, MemberAuth memberAuth) {
         TravelPlan travelPlan = getTravelPlanById(planId);
         Member member = getMemberByMemberAuth(memberAuth);
-        validateAuthor(travelPlan, member);
+        validateReadByAuthor(travelPlan, member);
 
         return TravelPlanResponse.of(travelPlan, getTravelPlanDayResponses(travelPlan));
     }
 
-    private void validateAuthor(TravelPlan travelPlan, Member member) {
+    private void validateReadByAuthor(TravelPlan travelPlan, Member member) {
         if (!travelPlan.isAuthor(member)) {
-            throw new ForbiddenException("작성자만 가능합니다.");
+            throw new ForbiddenException("여행 계획 조회는 작성자만 가능합니다.");
         }
     }
 
@@ -153,10 +153,16 @@ public class TravelPlanService {
     public void deleteByTravelPlanId(Long planId, MemberAuth memberAuth) {
         TravelPlan travelPlan = getTravelPlanById(planId);
         Member author = getMemberByMemberAuth(memberAuth);
-        validateAuthor(travelPlan, author);
+        validateDeleteByAuthor(travelPlan, author);
 
         travelPlanPlaceRepository.deleteByDayPlan(travelPlan);
         travelPlanDayRepository.deleteByPlan(travelPlan);
         travelPlanRepository.delete(travelPlan);
+    }
+
+    private void validateDeleteByAuthor(TravelPlan travelPlan, Member member) {
+        if (!travelPlan.isAuthor(member)) {
+            throw new ForbiddenException("여행 계획 삭제는 작성자만 가능합니다.");
+        }
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -134,6 +134,10 @@ public class TravelPlanService {
 
     @Transactional
     public void deleteByTravelPlanId(Long planId) {
+        if (!travelPlanRepository.existsById(planId)) {
+            throw new BadRequestException("존재하지 않는 여행 계획입니다.");
+        }
+
         travelPlanPlaceRepository.deleteByDayPlanId(planId);
         travelPlanDayRepository.deleteByPlanId(planId);
         travelPlanRepository.deleteById(planId);

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -147,4 +147,18 @@ class TravelogueControllerTest {
                 .then().log().all()
                 .statusCode(204);
     }
+
+    @DisplayName("존재하지 않는 여행기 삭제시 400를 응답한다.")
+    @Test
+    void deleteTravelogueWithNonExist() {
+        Member member = testHelper.initMemberTestData();
+        String accessToken = jwtTokenProvider.createToken(member.getId());
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travelogues/1")
+                .then().log().all()
+                .statusCode(400)
+                .body("message", is("존재하지 않는 여행기입니다."));
+    }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -133,4 +133,18 @@ class TravelogueControllerTest {
                 .statusCode(400).assertThat()
                 .body("message", is("존재하지 않는 여행기입니다."));
     }
+
+    @DisplayName("여행기를 삭제한다.")
+    @Test
+    void deleteTravelogue() {
+        testHelper.initTravelogueTestData();
+        Member member = testHelper.initMemberTestData();
+        String accessToken = jwtTokenProvider.createToken(member.getId());
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travelogues/1")
+                .then().log().all()
+                .statusCode(204);
+    }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -175,6 +175,6 @@ class TravelogueControllerTest {
                 .when().delete("/api/v1/travelogues/" + travelogue.getId())
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("작성자만 가능합니다."));
+                .body("message", is("여행기 삭제는 작성자만 가능합니다."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -11,6 +11,7 @@ import kr.touroot.authentication.infrastructure.JwtTokenProvider;
 import kr.touroot.global.AcceptanceTest;
 import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
+import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.response.TravelogueResponse;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
@@ -137,8 +138,8 @@ class TravelogueControllerTest {
     @DisplayName("여행기를 삭제한다.")
     @Test
     void deleteTravelogue() {
-        testHelper.initTravelogueTestData();
         Member member = testHelper.initMemberTestData();
+        testHelper.initTravelogueTestData(member);
         String accessToken = jwtTokenProvider.createToken(member.getId());
 
         RestAssured.given().log().all()
@@ -160,5 +161,20 @@ class TravelogueControllerTest {
                 .then().log().all()
                 .statusCode(400)
                 .body("message", is("존재하지 않는 여행기입니다."));
+    }
+
+    @DisplayName("작성자가 아닌 사용자가 여행기 삭제시 403을 응답한다.")
+    @Test
+    void deleteTravelogueWithNotAuthor() {
+        Travelogue travelogue = testHelper.initTravelogueTestData();
+        Member notAuthor = testHelper.initMemberTestData();
+        String accessToken = jwtTokenProvider.createToken(notAuthor.getId());
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travelogues/" + travelogue.getId())
+                .then().log().all()
+                .statusCode(403)
+                .body("message", is("작성자만 가능합니다."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
@@ -49,13 +49,19 @@ public class TravelogueTestHelper {
         this.memberRepository = memberRepository;
     }
 
-    public void initTravelogueTestData() {
+    public Travelogue initTravelogueTestData() {
         Member author = persistMember();
+        return initTravelogueTestData(author);
+    }
+
+    public Travelogue initTravelogueTestData(Member author) {
         Travelogue travelogue = persistTravelogue(author);
         TravelogueDay day = persistTravelogueDay(travelogue);
         Place position = persistPlace();
         TraveloguePlace place = persistTraveloguePlace(position, day);
         persistTraveloguePhoto(place);
+
+        return travelogue;
     }
 
     public Member persistMember() {

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueDayServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueDayServiceTest.java
@@ -96,15 +96,16 @@ class TravelogueDayServiceTest {
                 .hasMessage("존재하지 않는 여행기 일자입니다.");
     }
 
-    @DisplayName("여행기 일자를 여행기 ID 기준으로 삭제할 수 있다.")
+    @DisplayName("주어진 여행기의 여행기 일자를 삭제할 수 있다.")
     @Test
     void deleteTravelogueDayById() {
-        testHelper.initTravelogueTestData();
-        dayService.deleteByTravelogueId(1L);
+        Travelogue travelogue = testHelper.initTravelogueTestData();
+        long travelogueId = travelogue.getId();
+        dayService.deleteByTravelogue(travelogue);
 
         assertThat(dayRepository.findAll()
                 .stream()
-                .noneMatch(day -> extractTravelogue(day).getId() == 1L))
+                .noneMatch(day -> extractTravelogue(day).getId() == travelogueId))
                 .isTrue();
     }
 

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueDayServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueDayServiceTest.java
@@ -16,6 +16,7 @@ import kr.touroot.travelogue.dto.request.TravelogueDayRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
 import kr.touroot.travelogue.helper.TravelogueTestHelper;
+import kr.touroot.travelogue.repository.TravelogueDayRepository;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,16 +30,19 @@ import org.springframework.context.annotation.Import;
 class TravelogueDayServiceTest {
 
     private final TravelogueDayService dayService;
+    private final TravelogueDayRepository dayRepository;
     private final DatabaseCleaner databaseCleaner;
     private final TravelogueTestHelper testHelper;
 
     @Autowired
     public TravelogueDayServiceTest(
             TravelogueDayService dayService,
+            TravelogueDayRepository dayRepository,
             DatabaseCleaner databaseCleaner,
             TravelogueTestHelper testHelper
     ) {
         this.dayService = dayService;
+        this.dayRepository = dayRepository;
         this.databaseCleaner = databaseCleaner;
         this.testHelper = testHelper;
     }
@@ -90,5 +94,21 @@ class TravelogueDayServiceTest {
         assertThatThrownBy(() -> dayService.findDayById(1L))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("존재하지 않는 여행기 일자입니다.");
+    }
+
+    @DisplayName("여행기 일자를 여행기 ID 기준으로 삭제할 수 있다.")
+    @Test
+    void deleteTravelogueDayById() {
+        testHelper.initTravelogueTestData();
+        dayService.deleteByTravelogueId(1L);
+
+        assertThat(dayRepository.findAll()
+                .stream()
+                .noneMatch(day -> extractTravelogue(day).getId() == 1L))
+                .isTrue();
+    }
+
+    private Travelogue extractTravelogue(TravelogueDay day) {
+        return day.getTravelogue();
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -1,10 +1,12 @@
 package kr.touroot.travelogue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import kr.touroot.global.ServiceTest;
 import kr.touroot.global.auth.dto.MemberAuth;
+import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.service.MemberService;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
@@ -96,5 +98,16 @@ class TravelogueFacadeServiceTest {
 
         assertThat(service.findTravelogues(Pageable.ofSize(5)))
                 .isEqualTo(responses);
+    }
+
+    @DisplayName("여행기를 ID를 기준으로 삭제한다.")
+    @Test
+    void deleteById() {
+        testHelper.initTravelogueTestData();
+        service.deleteTravelogueById(1L);
+
+        assertThatThrownBy(() -> service.findTravelogueById(1L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행기입니다.");
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -131,6 +131,6 @@ class TravelogueFacadeServiceTest {
 
         assertThatThrownBy(() -> service.deleteTravelogueById(1L, notAuthorAuth))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("작성자만 가능합니다.");
+                .hasMessage("여행기 삭제는 작성자만 가능합니다.");
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
@@ -15,6 +15,8 @@ import kr.touroot.travelogue.domain.TraveloguePlace;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
 import kr.touroot.travelogue.helper.TravelogueTestHelper;
+import kr.touroot.utils.DatabaseCleaner;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -29,6 +31,7 @@ class TraveloguePhotoServiceTest {
 
     private final TraveloguePhotoService photoService;
     private final TravelogueTestHelper testHelper;
+    private final DatabaseCleaner databaseCleaner;
     @MockBean
     private final AwsS3Provider s3Provider;
 
@@ -36,11 +39,18 @@ class TraveloguePhotoServiceTest {
     public TraveloguePhotoServiceTest(
             TraveloguePhotoService photoService,
             TravelogueTestHelper testHelper,
+            DatabaseCleaner databaseCleaner,
             AwsS3Provider s3Provider
     ) {
         this.photoService = photoService;
         this.testHelper = testHelper;
+        this.databaseCleaner = databaseCleaner;
         this.s3Provider = s3Provider;
+    }
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.executeTruncate();
     }
 
     @DisplayName("여행기 사진을 생성한다.")

--- a/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePhotoServiceTest.java
@@ -90,15 +90,16 @@ class TraveloguePhotoServiceTest {
         assertThat(photoUrls).contains(photo.getKey());
     }
 
-    @DisplayName("여행기 사진을 여행기 ID 기준으로 삭제할 수 있다.")
+    @DisplayName("주어진 여행기의 여행기 사진을 삭제할 수 있다.")
     @Test
     void deleteTraveloguePhotoById() {
-        testHelper.initTravelogueTestData();
-        photoService.deleteByTravelogueId(1L);
+        Travelogue travelogue = testHelper.initTravelogueTestData();
+        long travelogueId = travelogue.getId();
+        photoService.deleteByTravelogue(travelogue);
 
         assertThat(photoRepository.findAll()
                 .stream()
-                .noneMatch(photo -> extractTravelogue(photo).getId() == 1L))
+                .noneMatch(photo -> extractTravelogue(photo).getId() == travelogueId))
                 .isTrue();
     }
 

--- a/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePlaceServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePlaceServiceTest.java
@@ -18,6 +18,7 @@ import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
 import kr.touroot.travelogue.helper.TravelogueTestHelper;
+import kr.touroot.travelogue.repository.TraveloguePlaceRepository;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,16 +32,19 @@ import org.springframework.context.annotation.Import;
 class TraveloguePlaceServiceTest {
 
     private final TraveloguePlaceService placeService;
+    private final TraveloguePlaceRepository placeRepository;
     private final DatabaseCleaner databaseCleaner;
     private final TravelogueTestHelper testHelper;
 
     @Autowired
     public TraveloguePlaceServiceTest(
             TraveloguePlaceService placeService,
+            TraveloguePlaceRepository placeRepository,
             DatabaseCleaner databaseCleaner,
             TravelogueTestHelper testHelper
     ) {
         this.placeService = placeService;
+        this.placeRepository = placeRepository;
         this.databaseCleaner = databaseCleaner;
         this.testHelper = testHelper;
     }
@@ -95,5 +99,22 @@ class TraveloguePlaceServiceTest {
         assertThatThrownBy(() -> placeService.findTraveloguePlaceById(1L))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("존재하지 않는 여행기 장소입니다.");
+    }
+
+    @DisplayName("여행기 장소를 여행기 ID 기준으로 삭제할 수 있다.")
+    @Test
+    void deleteTraveloguePlaceById() {
+        testHelper.initTravelogueTestData();
+        placeService.deleteByTravelogueId(1L);
+
+        assertThat(placeRepository.findAll()
+                .stream()
+                .noneMatch(place -> extractTravelogue(place).getId() == 1L))
+                .isTrue();
+    }
+
+    private Travelogue extractTravelogue(TraveloguePlace place) {
+        return place.getTravelogueDay()
+                .getTravelogue();
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePlaceServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TraveloguePlaceServiceTest.java
@@ -101,15 +101,16 @@ class TraveloguePlaceServiceTest {
                 .hasMessage("존재하지 않는 여행기 장소입니다.");
     }
 
-    @DisplayName("여행기 장소를 여행기 ID 기준으로 삭제할 수 있다.")
+    @DisplayName("주어진 여행기의 여행기 장소를 삭제할 수 있다.")
     @Test
     void deleteTraveloguePlaceById() {
-        testHelper.initTravelogueTestData();
-        placeService.deleteByTravelogueId(1L);
+        Travelogue travelogue = testHelper.initTravelogueTestData();
+        long travelogueId = travelogue.getId();
+        placeService.deleteByTravelogue(travelogue);
 
         assertThat(placeRepository.findAll()
                 .stream()
-                .noneMatch(place -> extractTravelogue(place).getId() == 1L))
+                .noneMatch(place -> extractTravelogue(place).getId() == travelogueId))
                 .isTrue();
     }
 

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
@@ -108,4 +108,12 @@ class TravelogueServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("존재하지 않는 여행기입니다.");
     }
+
+    @DisplayName("존재하지 않는 ID로 여행기를 삭제하면 예외가 발생한다.")
+    @Test
+    void deleteTravelogueByNotExistsIdThrowException() {
+        assertThatThrownBy(() -> travelogueService.deleteById(1L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행기입니다.");
+    }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
@@ -121,6 +121,6 @@ class TravelogueServiceTest {
 
         assertThatThrownBy(() -> travelogueService.delete(travelogue, notAuthor))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("작성자만 가능합니다.");
+                .hasMessage("여행기 삭제는 작성자만 가능합니다.");
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
@@ -97,4 +97,15 @@ class TravelogueServiceTest {
         assertThat(travelogueService.findAll(Pageable.ofSize(BASIC_PAGE_SIZE)))
                 .hasSize(1);
     }
+
+    @DisplayName("여행기를 ID 기준으로 삭제할 수 있다.")
+    @Test
+    void deleteTravelogueById() {
+        testHelper.initTravelogueTestData();
+        travelogueService.deleteById(1L);
+
+        assertThatThrownBy(() -> travelogueService.getTravelogueById(1L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행기입니다.");
+    }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
@@ -103,12 +103,12 @@ class TravelogueServiceTest {
     @Test
     void deleteTravelogueById() {
         Member author = testHelper.initMemberTestData();
-        Travelogue travelogue = testHelper.initTravelogueTestData();
+        Travelogue travelogue = testHelper.initTravelogueTestData(author);
         long travelogueId = travelogue.getId();
 
         travelogueService.delete(travelogue, author);
 
-        assertThatThrownBy(() -> travelogueService.getTravelogueById(1L))
+        assertThatThrownBy(() -> travelogueService.getTravelogueById(travelogueId))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("존재하지 않는 여행기입니다.");
     }

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -1,7 +1,11 @@
 package kr.touroot.travelplan.controller;
 
+import static org.hamcrest.Matchers.is;
+
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.util.List;
 import kr.touroot.authentication.infrastructure.JwtTokenProvider;
 import kr.touroot.global.AcceptanceTest;
 import kr.touroot.member.domain.Member;
@@ -17,11 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.hamcrest.Matchers.is;
 
 @DisplayName("여행 계획 컨트롤러")
 @AcceptanceTest
@@ -167,5 +166,18 @@ class TravelPlanControllerTest {
                 .body("message", is("여행 계획은 작성자만 조회할 수 있습니다."));
 
         // then
+    }
+
+    @DisplayName("여행기를 삭제한다.")
+    @Test
+    void deleteTravelogue() {
+        long id = testHelper.initTravelPlanTestData(member).getId();
+        String accessToken = jwtTokenProvider.createToken(member.getId());
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travel-plans/" + id)
+                .then().log().all()
+                .statusCode(204);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -168,9 +168,9 @@ class TravelPlanControllerTest {
         // then
     }
 
-    @DisplayName("여행기를 삭제한다.")
+    @DisplayName("여행계획을 삭제한다.")
     @Test
-    void deleteTravelogue() {
+    void deleteTravelPlan() {
         long id = testHelper.initTravelPlanTestData(member).getId();
         String accessToken = jwtTokenProvider.createToken(member.getId());
 
@@ -179,5 +179,19 @@ class TravelPlanControllerTest {
                 .when().delete("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(204);
+    }
+
+    @DisplayName("존재하지 않는 여행 계획 삭제시 400를 응답한다..")
+    @Test
+    void deleteTravelPlanWithNonExist() {
+        long id = 1L;
+        String accessToken = jwtTokenProvider.createToken(member.getId());
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travel-plans/" + id)
+                .then().log().all()
+                .statusCode(400)
+                .body("message", is("존재하지 않는 여행 계획입니다."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -29,12 +29,12 @@ import org.springframework.http.HttpHeaders;
 @AcceptanceTest
 class TravelPlanControllerTest {
 
-    @LocalServerPort
-    private int port;
     private final ObjectMapper objectMapper;
     private final DatabaseCleaner databaseCleaner;
     private final JwtTokenProvider jwtTokenProvider;
     private final TravelPlanTestHelper testHelper;
+    @LocalServerPort
+    private int port;
     private String accessToken;
     private Member member;
 
@@ -169,7 +169,7 @@ class TravelPlanControllerTest {
                 .get("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("작성자만 가능합니다."));
+                .body("message", is("여행 계획 조회는 작성자만 가능합니다."));
     }
 
     @DisplayName("여행 계획 공유 키를 통해 여행 계획을 조회할 수 있다")
@@ -283,6 +283,6 @@ class TravelPlanControllerTest {
                 .when().delete("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("작성자만 가능합니다."));
+                .body("message", is("여행 계획 삭제는 작성자만 가능합니다."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -163,7 +163,7 @@ class TravelPlanControllerTest {
                 .get("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("여행 계획은 작성자만 조회할 수 있습니다."));
+                .body("message", is("작성자만 가능합니다."));
 
         // then
     }
@@ -181,7 +181,7 @@ class TravelPlanControllerTest {
                 .statusCode(204);
     }
 
-    @DisplayName("존재하지 않는 여행 계획 삭제시 400를 응답한다..")
+    @DisplayName("존재하지 않는 여행 계획 삭제시 400를 응답한다.")
     @Test
     void deleteTravelPlanWithNonExist() {
         long id = 1L;
@@ -193,5 +193,20 @@ class TravelPlanControllerTest {
                 .then().log().all()
                 .statusCode(400)
                 .body("message", is("존재하지 않는 여행 계획입니다."));
+    }
+
+    @DisplayName("작성자가 아닌 사용자가 여행 계획 삭제시 403을 응답한다.")
+    @Test
+    void deleteTravelPlanWithNotAuthor() {
+        long id = testHelper.initTravelPlanTestData(member).getId();
+        Member notAuthor = testHelper.initMemberTestData();
+        String notAuthorAccessToken = jwtTokenProvider.createToken(notAuthor.getId());
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + notAuthorAccessToken)
+                .when().delete("/api/v1/travel-plans/" + id)
+                .then().log().all()
+                .statusCode(403)
+                .body("message", is("작성자만 가능합니다."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -144,7 +144,7 @@ class TravelPlanServiceTest {
         // when & then
         assertThatThrownBy(() -> travelPlanService.readTravelPlan(id, notAuthor))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("작성자만 가능합니다.");
+                .hasMessage("여행 계획 조회는 작성자만 가능합니다.");
     }
 
     @DisplayName("여행 계획 서비스는 여행 계획 일자를 계산해 반환한다.")
@@ -193,7 +193,7 @@ class TravelPlanServiceTest {
         // when & then
         assertThatThrownBy(() -> travelPlanService.deleteByTravelPlanId(id, notAuthor))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("작성자만 가능합니다.");
+                .hasMessage("여행 계획 삭제는 작성자만 가능합니다.");
     }
 
     @DisplayName("여행 계획 서비스는 공유 키로 여행 계획을 조회할 수 있다")

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -143,7 +143,7 @@ class TravelPlanServiceTest {
         // when & then
         assertThatThrownBy(() -> travelPlanService.readTravelPlan(id, notAuthor))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("여행 계획은 작성자만 조회할 수 있습니다.");
+                .hasMessage("작성자만 가능합니다.");
     }
 
     @DisplayName("여행 계획 서비스는 여행 계획 일자를 계산해 반환한다.")
@@ -163,7 +163,7 @@ class TravelPlanServiceTest {
     @Test
     void deleteTravelPlanById() {
         TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
-        travelPlanService.deleteByTravelPlanId(travelPlan.getId());
+        travelPlanService.deleteByTravelPlanId(travelPlan.getId(), memberAuth);
 
         assertThat(travelPlanRepository.findById(travelPlan.getId()))
                 .isEmpty();
@@ -177,8 +177,21 @@ class TravelPlanServiceTest {
         Long id = 1L;
 
         // when & then
-        assertThatThrownBy(() -> travelPlanService.deleteByTravelPlanId(id))
+        assertThatThrownBy(() -> travelPlanService.deleteByTravelPlanId(id, memberAuth))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("존재하지 않는 여행 계획입니다.");
+    }
+
+    @DisplayName("여행 계획 서비스는 작성자가 아닌 사용자가 삭제 시 예외를 반환한다.")
+    @Test
+    void deleteTravelPlanWithNotAuthor() {
+        // given
+        Long id = testHelper.initTravelPlanTestData(author).getId();
+        MemberAuth notAuthor = new MemberAuth(testHelper.initMemberTestData().getId());
+
+        // when & then
+        assertThatThrownBy(() -> travelPlanService.deleteByTravelPlanId(id, notAuthor))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("작성자만 가능합니다.");
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -1,5 +1,10 @@
 package kr.touroot.travelplan.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
 import kr.touroot.global.ServiceTest;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.BadRequestException;
@@ -13,6 +18,7 @@ import kr.touroot.travelplan.dto.request.TravelPlanCreateRequest;
 import kr.touroot.travelplan.dto.response.TravelPlanCreateResponse;
 import kr.touroot.travelplan.dto.response.TravelPlanResponse;
 import kr.touroot.travelplan.helper.TravelPlanTestHelper;
+import kr.touroot.travelplan.repository.TravelPlanRepository;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,18 +26,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @DisplayName("여행 계획 서비스")
 @Import(value = {TravelPlanService.class, TravelPlanTestHelper.class})
 @ServiceTest
 class TravelPlanServiceTest {
 
     private final TravelPlanService travelPlanService;
+    private final TravelPlanRepository travelPlanRepository;
     private final DatabaseCleaner databaseCleaner;
     private final TravelPlanTestHelper testHelper;
 
@@ -41,10 +42,12 @@ class TravelPlanServiceTest {
     @Autowired
     public TravelPlanServiceTest(
             TravelPlanService travelPlanService,
+            TravelPlanRepository travelPlanRepository,
             DatabaseCleaner databaseCleaner,
             TravelPlanTestHelper testHelper
     ) {
         this.travelPlanService = travelPlanService;
+        this.travelPlanRepository = travelPlanRepository;
         this.databaseCleaner = databaseCleaner;
         this.testHelper = testHelper;
     }
@@ -154,5 +157,15 @@ class TravelPlanServiceTest {
 
         // then
         assertThat(actual).isEqualTo(1);
+    }
+
+    @DisplayName("여행계획을 ID 기준으로 삭제할 수 있다.")
+    @Test
+    void deleteTravelPlanById() {
+        TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
+        travelPlanService.deleteByTravelPlanId(travelPlan.getId());
+
+        assertThat(travelPlanRepository.findById(travelPlan.getId()))
+                .isEmpty();
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -168,4 +168,17 @@ class TravelPlanServiceTest {
         assertThat(travelPlanRepository.findById(travelPlan.getId()))
                 .isEmpty();
     }
+
+    @DisplayName("여행 계획 서비스는 존재하지 않는 여행 계획 삭제 시 예외를 반환한다.")
+    @Test
+    void deleteTravelPlanWitNonExist() {
+        // given
+        databaseCleaner.executeTruncate();
+        Long id = 1L;
+
+        // when & then
+        assertThatThrownBy(() -> travelPlanService.deleteByTravelPlanId(id))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행 계획입니다.");
+    }
 }


### PR DESCRIPTION
# ✅ 작업 내용

- 여행기, 여행 계획 soft delete 구현
- 없는 여행기, 여행 계획 삭제 시 400 예외를 발생시키는 기능 구현
- 작성자가 아닌 사용자가 삭제 시 403 예외를 발생시키는 기능 구현 

# 🙈 참고 사항
앞으로 트랜잭션 내에서만 외래키 제약 조건이 활성화 됩니다.
단일 데이터 삭제 시, soft delet로 인해 DB 단에서는 제약 조건이 터지지 않기 때문에 어플리케이션 레벨에서 잘 신경 써 주셔야 합니다.

S3 이미지 삭제는 좀 더 이야기 해 보아야 할 것 같습니다.