### PR TITLE
[Fix] - JwtAuthFilter Authorization Header 파싱 오류 수정

### DIFF
--- a/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (token == null) {
+        if (token == null || token.isBlank()) {
             sendUnauthorizedResponse(response, "로그인을 해주세요.");
             return;
         }


### PR DESCRIPTION
# ✅ 작업 내용

- JwtAuthFilter에서 Bearer로 인증 헤더 split할 때 발생하는 오류 수정

