### PR TITLE
[Refactor] - 메인 페이지 여행기 목록 응답에 사용자 프로필 사진 URL 추가

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -97,4 +97,8 @@ public class Travelogue extends BaseEntity {
     public String getAuthorNickname() {
         return author.getNickname();
     }
+
+    public String getAuthorProfileImageUrl() {
+        return author.getProfileImageUrl();
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
@@ -14,7 +14,9 @@ public record TravelogueResponse(
         String title,
         @Schema(description = "작성자 닉네임", example = "지니")
         String authorNickname,
-        @Schema(description = "여행기 썸네일 링크", example = "https://썸네일.png")
+        @Schema(description = "작성자 프로필 사진 URL", example = "https://dev.touroot.kr/images/profile.png")
+        String authorProfileImageUrl,
+        @Schema(description = "여행기 썸네일 링크", example = "https://dev.touroot.kr/images/thumbnail.png")
         String thumbnail,
         @Schema(description = "작성 날짜")
         LocalDate createdAt,
@@ -27,6 +29,7 @@ public record TravelogueResponse(
                 .id(travelogue.getId())
                 .createdAt(travelogue.getCreatedAt().toLocalDate())
                 .authorNickname(travelogue.getAuthorNickname())
+                .authorProfileImageUrl(travelogue.getAuthorProfileImageUrl())
                 .title(travelogue.getTitle())
                 .thumbnail(travelogue.getThumbnail())
                 .days(days)

--- a/backend/src/test/java/kr/touroot/authentication/fixture/MemberFixture.java
+++ b/backend/src/test/java/kr/touroot/authentication/fixture/MemberFixture.java
@@ -9,8 +9,14 @@ import lombok.Getter;
 @Getter
 public enum MemberFixture {
 
-    MEMBER_KAKAO(new Member(1L, "리비", "http://imageurl.com", LoginType.KAKAO)),
-    MEMBER_DEFAULT(new Member("user@email.com", "5304d46adc6ccffd0", "뚜리", "http://imageurl.com", LoginType.DEFAULT));
+    MEMBER_KAKAO(new Member(1L, "리비", "https://dev.touroot.kr/temporary/profile.png", LoginType.KAKAO)),
+    MEMBER_DEFAULT(new Member(
+            "user@email.com",
+            "5304d46adc",
+            "뚜리",
+            "https://dev.touroot.kr/temporary/profile.png",
+            LoginType.DEFAULT
+    ));
 
     private final Member member;
 }

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
@@ -22,6 +22,7 @@ public class TravelogueResponseFixture {
                 .title("제주에 하영 옵서")
                 .createdAt(LocalDate.now())
                 .authorNickname("리비")
+                .authorProfileImageUrl("https://dev.touroot.kr/temporary/profile.png")
                 .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                 .days(getTravelogueDayResponses())
                 .build();
@@ -33,6 +34,7 @@ public class TravelogueResponseFixture {
                 .title("제주에 하영 옵서")
                 .createdAt(LocalDate.now())
                 .authorNickname("리비")
+                .authorProfileImageUrl("https://dev.touroot.kr/temporary/profile.png")
                 .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                 .days(getTravelogueDayResponses())
                 .build()));

--- a/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
@@ -110,7 +110,7 @@ public class TravelogueTestHelper {
     }
 
     public Member initKakaoMemberTestData() {
-        Member member = new Member(1L, "리비", "http://image.com", LoginType.KAKAO);
+        Member member = new Member(1L, "리비", "https://dev.touroot.kr/temporary/profile.png", LoginType.KAKAO);
         return memberRepository.save(member);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/helper/TravelPlanTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelplan/helper/TravelPlanTestHelper.java
@@ -90,7 +90,7 @@ public class TravelPlanTestHelper {
     }
 
     public Member initMemberTestData() {
-        Member member = getKakaoMember(1L, "tester", "http://image.com");
+        Member member = getKakaoMember(1L, "tester", "https://dev.touroot.kr/temporary/profile.png");
         return memberRepository.save(member);
     }
 }


### PR DESCRIPTION
# ✅ 작업 내용

- `TravelogueResponse`에 `authorProfileImageUrl` 추가
