### PR TITLE
[Fix] - 3차 스프린트 QA 반영(리버) 

### DIFF
--- a/frontend/src/components/common/Calendar/Calendar.styled.ts
+++ b/frontend/src/components/common/Calendar/Calendar.styled.ts
@@ -6,7 +6,7 @@ import { PRIMITIVE_COLORS } from "@styles/tokens";
 export const Layout = styled.div`
   overflow: hidden;
   position: relative;
-  z-index: 1000;
+
   width: 100%;
   border: 0.1rem solid ${({ theme }) => theme.colors.border};
   border-radius: 0.8rem;

--- a/frontend/src/components/common/Carousel/Carousel.styled.ts
+++ b/frontend/src/components/common/Carousel/Carousel.styled.ts
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 
 export const CarouselContainer = styled.div`
   overflow: hidden;
-  overflow: hidden;
   position: relative;
 
   width: 100%;
@@ -39,7 +38,7 @@ export const CarouselButton = styled.button`
   align-items: center;
   position: absolute;
   top: 50%;
-  z-index: 1;
+  z-index: ${({ theme }) => theme.zIndex.default};
 
   width: 32px;
   height: 32px;

--- a/frontend/src/components/common/Drawer/Drawer.styled.ts
+++ b/frontend/src/components/common/Drawer/Drawer.styled.ts
@@ -20,7 +20,7 @@ export const Overlay = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: ${({ theme }) => theme.zIndex.overlay};
+  z-index: ${({ theme }) => theme.zIndex.drawerOverlay};
   width: 100%;
   height: 100%;
 

--- a/frontend/src/components/common/Drawer/Drawer.styled.ts
+++ b/frontend/src/components/common/Drawer/Drawer.styled.ts
@@ -6,7 +6,7 @@ export const DrawerContainer = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
   right: ${({ isOpen }) => (isOpen ? "0" : "-210px")};
-  z-index: 10000;
+  z-index: 1100;
   width: 210px;
   height: 100%;
 
@@ -20,7 +20,7 @@ export const Overlay = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 999;
+  z-index: 1000;
   width: 100%;
   height: 100%;
 

--- a/frontend/src/components/common/Drawer/Drawer.styled.ts
+++ b/frontend/src/components/common/Drawer/Drawer.styled.ts
@@ -6,7 +6,7 @@ export const DrawerContainer = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
   right: ${({ isOpen }) => (isOpen ? "0" : "-210px")};
-  z-index: 1100;
+  z-index: ${({ theme }) => theme.zIndex.drawer};
   width: 210px;
   height: 100%;
 
@@ -20,7 +20,7 @@ export const Overlay = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
   width: 100%;
   height: 100%;
 

--- a/frontend/src/components/common/FloatingButton/FloatingButton.styled.ts
+++ b/frontend/src/components/common/FloatingButton/FloatingButton.styled.ts
@@ -11,7 +11,7 @@ export const Container = styled.div`
   position: fixed;
   right: max(2rem, calc(50% - 48rem / 2 + 2rem));
   bottom: 2rem;
-  z-index: 1000;
+  z-index: ${({ theme }) => theme.zIndex.floatingButton};
 `;
 
 export const ButtonGroup = styled.div<{ $isOpen: boolean }>`

--- a/frontend/src/components/common/GoogleSearchPopup/GoogleSearchPopup.styled.ts
+++ b/frontend/src/components/common/GoogleSearchPopup/GoogleSearchPopup.styled.ts
@@ -8,12 +8,12 @@ export const Layout = styled.div`
   flex-direction: column;
   position: fixed;
   top: 0;
-  z-index: 1000;
+  z-index: ${({ theme }) => theme.zIndex.modal};
   width: 100%;
   height: 100vh;
   max-width: 48rem;
 
-  background-color: #fff;
+  background-color: ${PRIMITIVE_COLORS.white};
   transform: translateX(-3.2rem);
 `;
 

--- a/frontend/src/components/common/Header/Header.styled.ts
+++ b/frontend/src/components/common/Header/Header.styled.ts
@@ -8,7 +8,7 @@ export const HeaderLayout = styled.header`
   align-items: center;
   position: fixed;
   top: 0;
-  z-index: 500;
+  z-index: ${({ theme }) => theme.zIndex.header};
 
   width: 100%;
   height: fit-content;

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -27,7 +27,10 @@ const Header = () => {
       : () => navigate(ROUTE_PATHS_MAP.back);
 
   const handleClickLogout = () => {
-    if (pathName.includes("travel-plan")) {
+    if (
+      pathName.includes(ROUTE_PATHS_MAP.travelPlan().split("/").shift()!) ||
+      pathName.includes(ROUTE_PATHS_MAP.my)
+    ) {
       navigate(ROUTE_PATHS_MAP.login);
     }
     saveUser({ accessToken: "" });

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -27,6 +27,9 @@ const Header = () => {
       : () => navigate(ROUTE_PATHS_MAP.back);
 
   const handleClickLogout = () => {
+    if (pathName.includes("travel-plan")) {
+      navigate(ROUTE_PATHS_MAP.login);
+    }
     saveUser({ accessToken: "" });
   };
   const handleClickMyPage = () => navigate(ROUTE_PATHS_MAP.my);

--- a/frontend/src/components/common/Modal/Modal.style.ts
+++ b/frontend/src/components/common/Modal/Modal.style.ts
@@ -8,7 +8,7 @@ export const Layout = styled.section`
   align-items: center;
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: ${({ theme }) => theme.zIndex.modal};
 `;
 
 export const BackdropLayout = styled.div`

--- a/frontend/src/components/common/ModalBottomSheet/BackDrop/BackDrop.styled.ts
+++ b/frontend/src/components/common/ModalBottomSheet/BackDrop/BackDrop.styled.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 export const BackDrop = styled.div`
   position: absolute;
   inset: 0;
-  z-index: 600;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
 
   background-color: ${({ theme }) => theme.colors.dimmed};
 `;

--- a/frontend/src/components/common/ModalBottomSheet/Container/Container.styled.ts
+++ b/frontend/src/components/common/ModalBottomSheet/Container/Container.styled.ts
@@ -7,7 +7,7 @@ export const Container = styled.div<{ $currentY: number }>`
   flex-direction: column;
   position: absolute;
   bottom: 0;
-  z-index: 700;
+  z-index: ${({ theme }) => theme.zIndex.bottomSheet};
 
   width: 100%;
   padding: 2.4rem;

--- a/frontend/src/components/common/Spinner/Spinner.stories.tsx
+++ b/frontend/src/components/common/Spinner/Spinner.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Spinner from "./Spinner";
+
+const meta = {
+  title: "common/Spinner",
+  component: Spinner,
+
+  parameters: {
+    layout: "fullscreen",
+    viewport: {
+      defaultViewport: "desktop",
+    },
+  },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/components/common/Spinner/Spinner.styled.ts
+++ b/frontend/src/components/common/Spinner/Spinner.styled.ts
@@ -1,0 +1,24 @@
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  svg {
+    width: 10rem;
+    height: 10rem;
+
+    animation: ${rotate} 0.5s linear infinite;
+  }
+`;

--- a/frontend/src/components/common/Spinner/Spinner.tsx
+++ b/frontend/src/components/common/Spinner/Spinner.tsx
@@ -1,0 +1,13 @@
+import { Tturi } from "@assets/svg";
+
+import * as S from "./Spinner.styled";
+
+const Spinner = () => {
+  return (
+    <S.Wrapper>
+      <Tturi />
+    </S.Wrapper>
+  );
+};
+
+export default Spinner;

--- a/frontend/src/components/common/Tab/Tab.styled.ts
+++ b/frontend/src/components/common/Tab/Tab.styled.ts
@@ -14,7 +14,7 @@ export const TabList = styled.ul`
 `;
 
 export const TabItem = styled.li<{ isSelected: boolean; $tabCount: number }>`
-  flex: 0 0 calc(100% / ${({ $tabCount }) => ($tabCount < 3 ? $tabCount : 3.5)});
+  flex: 0 0 calc(100% / ${({ $tabCount }) => ($tabCount <= 3 ? $tabCount : 3.5)});
   padding: 1rem 2rem;
   border-bottom: 2px solid ${(props) => (props.isSelected ? "#0090ff" : "transparent")};
 

--- a/frontend/src/components/common/Tab/Tab.tsx
+++ b/frontend/src/components/common/Tab/Tab.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, useRef, useState } from "react";
+import { ComponentPropsWithoutRef, useEffect, useRef, useState } from "react";
 
 import { STORAGE_KEYS_MAP } from "@constants/storage";
 
@@ -13,9 +13,21 @@ interface TabProps extends React.PropsWithChildren<ComponentPropsWithoutRef<"ul"
 const Tab = ({ labels, tabContent, ...props }: TabProps) => {
   const [selectedIndex, setSelectedIndex] = useState(() =>
     JSON.parse(
-      localStorage.getItem(STORAGE_KEYS_MAP.myPageSelectedTab) ?? FIRST_TAB_INDEX.toString(),
+      localStorage.getItem(STORAGE_KEYS_MAP.selectedTabIndex) ?? FIRST_TAB_INDEX.toString(),
     ),
   );
+
+  useEffect(() => {
+    const storedIndex = localStorage.getItem(STORAGE_KEYS_MAP.selectedTabIndex);
+    if (storedIndex !== null) {
+      setSelectedIndex(parseInt(storedIndex));
+    }
+
+    return () => {
+      localStorage.setItem(STORAGE_KEYS_MAP.selectedTabIndex, FIRST_TAB_INDEX.toString());
+    };
+  }, []);
+
   const tabRefs = useRef<(HTMLLIElement | null)[]>([]);
   const tabListRef = useRef<HTMLUListElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -24,7 +36,7 @@ const Tab = ({ labels, tabContent, ...props }: TabProps) => {
 
   const handleClickTab = (index: number) => {
     setSelectedIndex(index);
-    localStorage.setItem(STORAGE_KEYS_MAP.myPageSelectedTab, JSON.stringify(index));
+    localStorage.setItem(STORAGE_KEYS_MAP.selectedTabIndex, JSON.stringify(index));
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {

--- a/frontend/src/components/common/ThumbnailUpload/ThumbnailUpload.styled.ts
+++ b/frontend/src/components/common/ThumbnailUpload/ThumbnailUpload.styled.ts
@@ -43,7 +43,7 @@ export const ThumbnailUploadEditButton = styled.button`
 
 export const ThumbnailUploadEditButtonContainer = styled.div`
   position: relative;
-  z-index: 10;
+  z-index: ${({ theme }) => theme.zIndex.default};
   width: 100%;
   height: 100%;
 `;

--- a/frontend/src/components/common/Toast/Toast.styled.ts
+++ b/frontend/src/components/common/Toast/Toast.styled.ts
@@ -38,7 +38,7 @@ export const ToastContainerLayout = styled.div<{ $isOpen: boolean; $rect: DOMRec
   position: fixed;
   top: ${({ $rect }) => ($rect?.top ?? 0) + ($rect?.height ?? 0)}px;
   left: ${({ $rect }) => $rect?.left}px;
-  z-index: 1000;
+  z-index: ${({ theme }) => theme.zIndex.toast};
   width: ${({ $rect }) => $rect?.width}px;
 
   animation: ${({ $isOpen }) => ($isOpen ? slideInFromTop : slideOutToTop)} 0.5s ease-out;

--- a/frontend/src/components/pages/login/Fallback/LoginFallback.stories.ts
+++ b/frontend/src/components/pages/login/Fallback/LoginFallback.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import LoginFallback from "./LoginFallback";
+
+const meta = {
+  title: "common/LoginFallback",
+  component: LoginFallback,
+
+  parameters: {
+    layout: "fullscreen",
+    viewport: {
+      defaultViewport: "desktop",
+    },
+  },
+} satisfies Meta<typeof LoginFallback>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    mainText: "로그인 처리 중입니다",
+    subText: "잠시만 기다려주세요",
+  },
+};

--- a/frontend/src/components/pages/login/Fallback/LoginFallback.styled.ts
+++ b/frontend/src/components/pages/login/Fallback/LoginFallback.styled.ts
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+
+export const TturiImg = styled.img`
+  width: 26rem;
+  height: 26rem;
+`;
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3.2rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.m};
+`;
+
+export const MainText = styled.span`
+  ${({ theme }) => theme.typography.mobile.title};
+`;
+
+export const SubText = styled.span`
+  ${({ theme }) => theme.typography.mobile.bodyBold};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;

--- a/frontend/src/components/pages/login/Fallback/LoginFallback.tsx
+++ b/frontend/src/components/pages/login/Fallback/LoginFallback.tsx
@@ -1,0 +1,22 @@
+import Spinner from "@components/common/Spinner/Spinner";
+
+import * as S from "./LoginFallback.styled";
+
+interface LoginFallbackProps {
+  mainText: string;
+  subText?: string;
+}
+
+const LoginFallback = ({ mainText, subText }: LoginFallbackProps) => {
+  return (
+    <S.Layout>
+      <Spinner />
+      <S.TextContainer>
+        <S.MainText>{mainText}</S.MainText>
+        {subText && <S.SubText>{subText}</S.SubText>}
+      </S.TextContainer>
+    </S.Layout>
+  );
+};
+
+export default LoginFallback;

--- a/frontend/src/components/pages/login/KakaoCallbackPage.tsx
+++ b/frontend/src/components/pages/login/KakaoCallbackPage.tsx
@@ -1,13 +1,15 @@
 import { useContext, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { SaveUserContext } from "@contexts/UserProvider";
-
 import { client } from "@apis/client";
+
+import { SaveUserContext } from "@contexts/UserProvider";
 
 import { API_ENDPOINT_MAP } from "@constants/endpoint";
 import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
 import { ROUTE_PATHS_MAP } from "@constants/route";
+
+import LoginFallback from "./Fallback/LoginFallback";
 
 const KakaoCallbackPage = () => {
   const navigate = useNavigate();
@@ -36,7 +38,7 @@ const KakaoCallbackPage = () => {
     }
   }, [navigate]);
 
-  return <div>로그인 처리 중...</div>;
+  return <LoginFallback mainText="로그인 처리 중입니다" subText="잠시만 기다려주세요" />;
 };
 
 export default KakaoCallbackPage;

--- a/frontend/src/components/pages/main/MainPage.tsx
+++ b/frontend/src/components/pages/main/MainPage.tsx
@@ -30,10 +30,10 @@ const MainPage = () => {
         </S.MainPageTraveloguesList>
       )}
       <S.MainPageTraveloguesList>
-        {travelogues.map(({ userAvatar, id, title, thumbnail, likes }) => (
+        {travelogues.map(({ authorProfileImageUrl, id, title, thumbnail, likes }) => (
           <TravelogueCard
             key={id}
-            travelogueOverview={{ userAvatar, id, title, thumbnail, likes }}
+            travelogueOverview={{ authorProfileImageUrl, id, title, thumbnail, likes }}
           />
         ))}
       </S.MainPageTraveloguesList>

--- a/frontend/src/components/pages/main/MainPage.tsx
+++ b/frontend/src/components/pages/main/MainPage.tsx
@@ -30,10 +30,10 @@ const MainPage = () => {
         </S.MainPageTraveloguesList>
       )}
       <S.MainPageTraveloguesList>
-        {travelogues.map(({ authorProfileImageUrl, id, title, thumbnail, likes }) => (
+        {travelogues.map(({ authorProfileUrl, id, title, thumbnail, likes }) => (
           <TravelogueCard
             key={id}
-            travelogueOverview={{ authorProfileImageUrl, id, title, thumbnail, likes }}
+            travelogueOverview={{ authorProfileUrl, id, title, thumbnail, likes }}
           />
         ))}
       </S.MainPageTraveloguesList>

--- a/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.stories.tsx
+++ b/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
   component: TravelogueCard,
   argTypes: {
     travelogueOverview: {
-      userAvatar: { control: "text" },
+      authorProfileImageUrl: { control: "text" },
       title: { control: "text" },
       thumbnail: { control: "text" },
       likes: { control: "number" },
@@ -32,7 +32,8 @@ export const Default: Story = {
   args: {
     travelogueOverview: {
       id: 1,
-      userAvatar: "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
+      authorProfileImageUrl:
+        "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
       title: "갱얼쥐랑 캠핑 🐶",
       thumbnail: "https://i.pinimg.com/564x/20/bb/6d/20bb6d47bb88b8df862520c19c18600a.jpg",
       likes: 10,
@@ -44,7 +45,8 @@ export const WithInvalidThumbnail: Story = {
   args: {
     travelogueOverview: {
       id: 1,
-      userAvatar: "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
+      authorProfileImageUrl:
+        "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
       title: "갱얼쥐랑 캠핑 🐶",
       thumbnail: "invalidUrl",
       likes: 10,

--- a/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.stories.tsx
+++ b/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.stories.tsx
@@ -32,8 +32,7 @@ export const Default: Story = {
   args: {
     travelogueOverview: {
       id: 1,
-      authorProfileImageUrl:
-        "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
+      authorProfileUrl: "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
       title: "갱얼쥐랑 캠핑 🐶",
       thumbnail: "https://i.pinimg.com/564x/20/bb/6d/20bb6d47bb88b8df862520c19c18600a.jpg",
       likes: 10,
@@ -45,8 +44,7 @@ export const WithInvalidThumbnail: Story = {
   args: {
     travelogueOverview: {
       id: 1,
-      authorProfileImageUrl:
-        "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
+      authorProfileUrl: "https://i.pinimg.com/564x/c0/d6/5e/c0d65ef2ff5b3e752b70fe54d94d6206.jpg",
       title: "갱얼쥐랑 캠핑 🐶",
       thumbnail: "invalidUrl",
       likes: 10,

--- a/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.tsx
+++ b/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.tsx
@@ -17,9 +17,10 @@ interface TravelogueCardProps {
 }
 
 const TravelogueCard = ({
-  travelogueOverview: { id, authorProfileImageUrl, title, thumbnail, likes = 0 },
+  travelogueOverview: { id, authorProfileUrl, title, thumbnail, likes = 0 },
 }: TravelogueCardProps) => {
   const navigate = useNavigate();
+
   const { imageError, handleImageError } = useImageError({ imageUrl: thumbnail });
 
   const handleCardClick = () => {
@@ -45,7 +46,7 @@ const TravelogueCard = ({
       </S.TravelogueCardThumbnailContainer>
       <S.TravelogueCardHeader>
         <S.TravelogueCardTitleContainer>
-          <AvatarCircle profileImageUrl={authorProfileImageUrl} />
+          <AvatarCircle profileImageUrl={authorProfileUrl} />
           <h2>{title}</h2>
         </S.TravelogueCardTitleContainer>
 

--- a/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.tsx
+++ b/frontend/src/components/pages/main/TravelogueCard/TravelogueCard.tsx
@@ -17,7 +17,7 @@ interface TravelogueCardProps {
 }
 
 const TravelogueCard = ({
-  travelogueOverview: { id, userAvatar, title, thumbnail, likes = 0 },
+  travelogueOverview: { id, authorProfileImageUrl, title, thumbnail, likes = 0 },
 }: TravelogueCardProps) => {
   const navigate = useNavigate();
   const { imageError, handleImageError } = useImageError({ imageUrl: thumbnail });
@@ -45,7 +45,7 @@ const TravelogueCard = ({
       </S.TravelogueCardThumbnailContainer>
       <S.TravelogueCardHeader>
         <S.TravelogueCardTitleContainer>
-          <AvatarCircle profileImageUrl={userAvatar} />
+          <AvatarCircle profileImageUrl={authorProfileImageUrl} />
           <h2>{title}</h2>
         </S.TravelogueCardTitleContainer>
 

--- a/frontend/src/components/pages/travelPlanDetail/TravelPlanDetailPage.styled.ts
+++ b/frontend/src/components/pages/travelPlanDetail/TravelPlanDetailPage.styled.ts
@@ -28,5 +28,17 @@ export const cursorPointerStyle = css`
 `;
 
 export const summaryTitleStyle = css`
-  margin: 3.2rem 1.6rem 1.6rem;
+  margin: 3rem 1.6rem;
+`;
+
+export const dateStyle = css`
+  margin: 3rem 1.6rem;
+  margin-bottom: 3rem;
+`;
+
+export const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 3rem 1.6rem;
+  gap: ${({ theme }) => theme.spacing.m};
 `;

--- a/frontend/src/components/pages/travelPlanDetail/TravelPlanDetailPage.tsx
+++ b/frontend/src/components/pages/travelPlanDetail/TravelPlanDetailPage.tsx
@@ -13,6 +13,7 @@ import TravelPlansTabContent from "@components/pages/travelPlanDetail/TravelPlan
 import { ROUTE_PATHS_MAP } from "@constants/route";
 
 import { extractId } from "@utils/extractId";
+import getDateRange from "@utils/getDateRange";
 
 import theme from "@styles/theme";
 
@@ -93,9 +94,12 @@ const TravelPlanDetailPage = () => {
         </S.IconButtonContainer>
       </S.TitleContainer>
 
-      <Text textType="subTitle" css={S.summaryTitleStyle}>
-        {daysAndNights} 여행 계획 한 눈에 보기
-      </Text>
+      <S.TextContainer>
+        <Text textType="subTitle">{daysAndNights} 여행 계획 한 눈에 보기</Text>
+        <Text textType="detail">
+          {getDateRange({ daysLength: data?.days.length, startDate: data?.startDate })}
+        </Text>
+      </S.TextContainer>
 
       <Tab
         labels={data?.days.map((_, index: number) => `Day ${index + 1}`) ?? []}
@@ -104,7 +108,7 @@ const TravelPlanDetailPage = () => {
         )}
       />
       <TransformBottomSheet
-        onTransform={() => onTransformTravelDetail("/travelogue/register", data)}
+        onTransform={() => onTransformTravelDetail(ROUTE_PATHS_MAP.travelogueRegister, data)}
         buttonLabel="여행기로 전환"
       >
         여행은 즐겁게 다녀오셨나요?

--- a/frontend/src/constants/storage.ts
+++ b/frontend/src/constants/storage.ts
@@ -1,4 +1,4 @@
 export const STORAGE_KEYS_MAP = {
   user: "tourootUser",
-  myPageSelectedTab: "myPageSelectedTab",
+  selectedTabIndex: "selectedTabIndex",
 } as const;

--- a/frontend/src/queries/useDeleteTravelPlan.ts
+++ b/frontend/src/queries/useDeleteTravelPlan.ts
@@ -14,7 +14,9 @@ const useDeleteTravelPlan = () => {
   return useMutation({
     mutationFn: (id: number) => authClient.delete(API_ENDPOINT_MAP.travelPlanDetail(id)),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS_MAP.travelPlan.all });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS_MAP.travelPlan.all,
+      });
       navigation(-1);
     },
     onError: (error) => {

--- a/frontend/src/queries/useDeleteTravelogue.ts
+++ b/frontend/src/queries/useDeleteTravelogue.ts
@@ -14,7 +14,13 @@ const useDeleteTravelogue = () => {
   return useMutation({
     mutationFn: (id: number) => authClient.delete(API_ENDPOINT_MAP.travelogueDetail(id)),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS_MAP.travelogue.all });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS_MAP.travelogue.all,
+      });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS_MAP.travelogue.me(),
+        refetchType: "inactive",
+      });
       navigation(-1);
     },
     onError: (error) => {

--- a/frontend/src/queries/usePostTravelogue.ts
+++ b/frontend/src/queries/usePostTravelogue.ts
@@ -31,7 +31,13 @@ export const usePostTravelogue = () => {
         })),
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS_MAP.travelogue.all });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS_MAP.travelogue.all,
+      });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS_MAP.travelogue.me(),
+        refetchType: "inactive",
+      });
     },
     onError: (error) => {
       alert(error);

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,11 +1,12 @@
 import { Theme } from "@emotion/react";
 
-import { SEMANTIC_COLORS, SPACING, TYPOGRAPHY } from "@styles/tokens";
+import { SEMANTIC_COLORS, SPACING, TYPOGRAPHY, Z_INDEX } from "@styles/tokens";
 
 const theme: Theme = {
   typography: TYPOGRAPHY,
   colors: SEMANTIC_COLORS,
   spacing: SPACING,
+  zIndex: Z_INDEX,
 };
 
 export default theme;

--- a/frontend/src/styles/tokens/index.ts
+++ b/frontend/src/styles/tokens/index.ts
@@ -1,3 +1,4 @@
 export * from "./colors";
 export * from "./typography";
 export * from "./spacing";
+export * from "./zIndex";

--- a/frontend/src/styles/tokens/zIndex.ts
+++ b/frontend/src/styles/tokens/zIndex.ts
@@ -1,6 +1,7 @@
 export const Z_INDEX = {
   toast: 1200,
   drawer: 1100,
+  drawerOverlay: 1050,
   modal: 1000,
   bottomSheet: 1000,
   overlay: 900,

--- a/frontend/src/styles/tokens/zIndex.ts
+++ b/frontend/src/styles/tokens/zIndex.ts
@@ -1,0 +1,12 @@
+export const Z_INDEX = {
+  toast: 1200,
+  drawer: 1100,
+  modal: 1000,
+  bottomSheet: 1000,
+  overlay: 900,
+  floatingButton: 850,
+  dropdown: 800,
+  header: 700,
+  footer: 600,
+  default: 1,
+} as const;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export interface TravelogueOverview {
   id: number;
-  userAvatar: string;
+  authorProfileImageUrl: string;
   title: string;
   thumbnail: string;
   likes: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export interface TravelogueOverview {
   id: number;
-  authorProfileImageUrl: string;
+  authorProfileUrl: string;
   title: string;
   thumbnail: string;
   likes: number;

--- a/frontend/src/types/style/emotion.d.ts
+++ b/frontend/src/types/style/emotion.d.ts
@@ -1,12 +1,12 @@
 import "@emotion/react";
 
-import { SEMANTIC_COLORS, TYPOGRAPHY } from "@styles/tokens";
-import { SPACING } from "@styles/tokens/spacing";
+import { SEMANTIC_COLORS, SPACING, TYPOGRAPHY, Z_INDEX } from "@styles/tokens";
 
 declare module "@emotion/react" {
   export interface Theme {
     typography: typeof TYPOGRAPHY;
     colors: typeof SEMANTIC_COLORS;
     spacing: typeof SPACING;
+    zIndex: typeof Z_INDEX;
   }
 }

--- a/frontend/src/utils/getDateRange.ts
+++ b/frontend/src/utils/getDateRange.ts
@@ -1,0 +1,18 @@
+import addDaysToDateString from "./addDaysToDateString";
+
+const getDateRange = ({
+  daysLength = 0,
+  startDate = "2024-00-00",
+}: {
+  daysLength?: number;
+  startDate?: string;
+}) => {
+  return daysLength > 1
+    ? `${startDate} - ${addDaysToDateString({
+        dateString: startDate,
+        daysToAdd: daysLength,
+      })}`
+    : `${startDate}`;
+};
+
+export default getDateRange;


### PR DESCRIPTION
# ✅ 작업 내용

- 여행 계획 상세 페이지 내에서 로그아웃 했을 때, 로그인 페이지로 이동할 수 있도록 처리해야된다.
- 처음 여행기 이동하면 탭이 제대로 적용이 안된다.
  - Tab 컴포넌트가 마운트될 때 로컬스토리지의 selected index로 값 초기화 안되고있음.
- Drawer가 transformbottomsheet 보다 z-index 높아야 된다.
- 메인페이지에 사용자 프로필 이미지 나오도록 수정한다.
- 여행기 삭제시, 내 여행기 불러오기 무효화하도록 수정
- 여행기 작성시, 내 여행기 불러오기 무효화하도록 수정 
- 여행계획 작성시, 내 여행계획 불러오기 무효화하도록 수정 -> 안되있음
- 로그인 처리중 화면 구현
- z-index를 디자인 토큰으로 정리
- 여행 계획 상세 조회 페이지에 날짜 관련 정보 추가
- Tab 컴포넌트에서 day 3개일때 이상하게 보이던거 수정

# 📸 스크린샷

<img width="599" alt="image" src="https://github.com/user-attachments/assets/b2fbdfa2-fbd7-4f0b-ad6e-75c9857eafa2">

# 🙈 참고 사항

X

