### PR TITLE
[Fix] - 장소 설명이 255자를 넘어가는 여행기, 여행 계획이 저장 되지 않는 오류 수정

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/domain/TraveloguePlace.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TraveloguePlace.java
@@ -35,6 +35,7 @@ public class TraveloguePlace extends BaseEntity {
     @Column(name = "PLACE_ORDER", nullable = false)
     private Integer order;
 
+    @Column(columnDefinition = "VARCHAR(300)")
     private String description;
 
     @JoinColumn(nullable = false)

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
@@ -30,6 +30,7 @@ public class TravelPlanPlace extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(columnDefinition = "VARCHAR(300)")
     private String description;
 
     @Column(name = "PLAN_PLACE_ORDER", nullable = false)


### PR DESCRIPTION
# ✅ 작업 내용

- 엔티티의 description 필드 컬럼 명세 수정

# 🙈 참고 사항
