### PR TITLE
[Fix] - InternalServerError 로깅 시 예외 스택 트레이스가 제대로 로깅되지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/kr/touroot/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/touroot/global/exception/GlobalExceptionHandler.java
@@ -39,7 +39,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ClientException.class)
     public ResponseEntity<ExceptionResponse> handleClientException(ClientException exception) {
-        log.error("CLIENT_EXCEPTION :: stackTrace = {}", exception.getStackTrace());
+        log.error("CLIENT_EXCEPTION :: stackTrace = ", exception);
 
         ExceptionResponse data = new ExceptionResponse(exception.getMessage());
         return ResponseEntity.internalServerError().body(data);
@@ -64,7 +64,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
-        log.error("EXCEPTION :: stackTrace = {}", exception.getStackTrace());
+        log.error("EXCEPTION :: stackTrace = ", exception);
 
         ExceptionResponse data = new ExceptionResponse("서버에 문제가 발생했습니다. 투룻에 문의해 주세요.");
         return ResponseEntity.internalServerError()


### PR DESCRIPTION
# ✅ 작업 내용

- 내부 서버 에러 로깅 시 스택 트레이스가 제대로 로깅되도록 구현

# 🙈 참고 사항
