### PR TITLE
Fix - image error 처리 누락, 여행기 삭제시 마이페이지로 넘어갈 때 tab 초기값 수정 , 여행기 썸네일

### DIFF
--- a/frontend/src/components/common/Tab/Tab.tsx
+++ b/frontend/src/components/common/Tab/Tab.tsx
@@ -6,25 +6,24 @@ import * as S from "./Tab.styled";
 import { FIRST_TAB_INDEX, INITIAL_SCROLL_LEFT, INITIAL_START_X } from "./constants";
 
 interface TabProps extends React.PropsWithChildren<ComponentPropsWithoutRef<"ul">> {
+  storageKey?: string;
   tabContent: (selectedIndex: number) => JSX.Element;
   labels: string[];
 }
 
-const Tab = ({ labels, tabContent, ...props }: TabProps) => {
+const Tab = ({
+  storageKey = STORAGE_KEYS_MAP.selectedTabIndex,
+  labels,
+  tabContent,
+  ...props
+}: TabProps) => {
   const [selectedIndex, setSelectedIndex] = useState(() =>
-    JSON.parse(
-      localStorage.getItem(STORAGE_KEYS_MAP.selectedTabIndex) ?? FIRST_TAB_INDEX.toString(),
-    ),
+    parseInt(JSON.parse(localStorage.getItem(storageKey) ?? FIRST_TAB_INDEX.toString())),
   );
 
   useEffect(() => {
-    const storedIndex = localStorage.getItem(STORAGE_KEYS_MAP.selectedTabIndex);
-    if (storedIndex !== null) {
-      setSelectedIndex(parseInt(storedIndex));
-    }
-
     return () => {
-      localStorage.setItem(STORAGE_KEYS_MAP.selectedTabIndex, FIRST_TAB_INDEX.toString());
+      localStorage.setItem(storageKey, FIRST_TAB_INDEX.toString());
     };
   }, []);
 
@@ -36,7 +35,7 @@ const Tab = ({ labels, tabContent, ...props }: TabProps) => {
 
   const handleClickTab = (index: number) => {
     setSelectedIndex(index);
-    localStorage.setItem(STORAGE_KEYS_MAP.selectedTabIndex, JSON.stringify(index));
+    localStorage.setItem(storageKey, JSON.stringify(index));
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {

--- a/frontend/src/components/pages/my/MyPage.tsx
+++ b/frontend/src/components/pages/my/MyPage.tsx
@@ -5,6 +5,8 @@ import { useUserProfile } from "@queries/useUserProfile";
 import { AvatarCircle, Tab, Text } from "@components/common";
 import MyPageSkeleton from "@components/pages/my/MyPageSkeleton/MyPageSkeleton";
 
+import { STORAGE_KEYS_MAP } from "@constants/storage";
+
 import * as S from "./MyPage.styled";
 import MyTravelPlans from "./MyTravelPlans/MyTravelPlans";
 import MyTravelogues from "./MyTravelogues/MyTravelogues";
@@ -27,6 +29,7 @@ const MyPage = () => {
       </Text>
 
       <Tab
+        storageKey={STORAGE_KEYS_MAP.myPageSelectedTabIndex}
         labels={["내 여행 계획", "내 여행기"]}
         tabContent={(selectedIndex) => (
           <>{selectedIndex === 0 ? <MyTravelPlans /> : <MyTravelogues />}</>

--- a/frontend/src/components/pages/travelogueDetail/Thumbnail/Thumbnail.styled.ts
+++ b/frontend/src/components/pages/travelogueDetail/Thumbnail/Thumbnail.styled.ts
@@ -1,13 +1,14 @@
 import styled from "@emotion/styled";
 
-export const Image = styled.img`
-  width: 100%;
-`;
-
 export const Wrapper = styled.div`
   overflow: hidden;
   width: 100%;
   height: 25rem;
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   object-position: center;
 `;

--- a/frontend/src/components/pages/travelogueDetail/TravelogueTabContent/PlaceDetailCard/PlaceDetailCard.stories.tsx
+++ b/frontend/src/components/pages/travelogueDetail/TravelogueTabContent/PlaceDetailCard/PlaceDetailCard.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import PlaceDetailCard from "./PlaceDetailCard";
+
+const meta = {
+  title: "Components/PlaceDetailCard",
+  component: PlaceDetailCard,
+  argTypes: {
+    index: { control: "number" },
+    title: { control: "text" },
+    imageUrls: { control: "object" },
+    description: { control: "text" },
+  },
+  decorators: [
+    (Story, context) => {
+      return (
+        <div style={{ width: "48rem" }}>
+          <Story args={{ ...context.args }} />
+        </div>
+      );
+    },
+  ],
+} satisfies Meta<typeof PlaceDetailCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    index: 1,
+    title: "제목 ㅋㅋ",
+    imageUrls: ["https://i.pinimg.com/564x/e3/cc/52/e3cc52244f9b6810a0321b35fe249fbf.jpg"],
+    description: "여행지 설명",
+  },
+};
+
+export const WithInvalidImage: Story = {
+  args: {
+    index: 1,
+    title: "제목 ㅋㅋ",
+    imageUrls: ["invalidUrl.com"],
+    description: "여행지 설명",
+  },
+};

--- a/frontend/src/components/pages/travelogueDetail/TravelogueTabContent/PlaceDetailCard/PlaceDetailCard.styled.ts
+++ b/frontend/src/components/pages/travelogueDetail/TravelogueTabContent/PlaceDetailCard/PlaceDetailCard.styled.ts
@@ -49,3 +49,11 @@ export const Image = styled.img`
   object-position: center;
   object-fit: cover;
 `;
+
+export const ImageWrapper = styled.div`
+  width: 100%;
+  height: 233px;
+
+  object-position: center;
+  object-fit: cover;
+`;

--- a/frontend/src/components/pages/travelogueDetail/TravelogueTabContent/PlaceDetailCard/PlaceDetailCard.tsx
+++ b/frontend/src/components/pages/travelogueDetail/TravelogueTabContent/PlaceDetailCard/PlaceDetailCard.tsx
@@ -1,4 +1,6 @@
-import { Carousel } from "@components/common";
+import { Carousel, FallbackImage } from "@components/common";
+
+import useImageError from "@hooks/useImageError";
 
 import * as S from "./PlaceDetailCard.styled";
 
@@ -15,11 +17,19 @@ const PlaceDetailCard: React.FC<PlaceDetailCardProps> = ({
   imageUrls,
   description,
 }) => {
+  const { imageError, handleImageError } = useImageError({ imageUrl: imageUrls[0] });
+
   return (
     <S.PlaceDetailCardLayout>
       <S.PlaceDetailCardTitle>{`${index}. ${title}`}</S.PlaceDetailCardTitle>
       {imageUrls.length === 1 ? (
-        <S.Image src={imageUrls[0]} alt={`${title} place`} />
+        !imageError ? (
+          <S.Image src={imageUrls[0]} alt={`${title} place`} onError={handleImageError} />
+        ) : (
+          <S.ImageWrapper>
+            <FallbackImage />
+          </S.ImageWrapper>
+        )
       ) : (
         <Carousel imageUrls={imageUrls} />
       )}

--- a/frontend/src/constants/storage.ts
+++ b/frontend/src/constants/storage.ts
@@ -1,4 +1,5 @@
 export const STORAGE_KEYS_MAP = {
   user: "tourootUser",
   selectedTabIndex: "selectedTabIndex",
+  myPageSelectedTabIndex: "myPageSelectedTabIndex",
 } as const;

--- a/frontend/src/queries/useDeleteTravelogue.ts
+++ b/frontend/src/queries/useDeleteTravelogue.ts
@@ -7,6 +7,7 @@ import { authClient } from "@apis/client";
 import { API_ENDPOINT_MAP } from "@constants/endpoint";
 import { QUERY_KEYS_MAP } from "@constants/queryKey";
 import { ROUTE_PATHS_MAP } from "@constants/route";
+import { STORAGE_KEYS_MAP } from "@constants/storage";
 
 const useDeleteTravelogue = () => {
   const queryClient = useQueryClient();
@@ -20,7 +21,10 @@ const useDeleteTravelogue = () => {
           queryKey: QUERY_KEYS_MAP.travelogue.all,
           refetchType: "inactive",
         })
-        .then(() => navigation(ROUTE_PATHS_MAP.my));
+        .then(() => {
+          navigation(ROUTE_PATHS_MAP.my);
+          localStorage.setItem(STORAGE_KEYS_MAP.myPageSelectedTabIndex, JSON.stringify(1));
+        });
     },
     onError: (error) => {
       alert(error.message);


### PR DESCRIPTION
# ✅ 작업 내용

- [x] 이미지 사진 한장일 때 image error 처리 누락
- [x] 여행기 삭제시 마이페이지로 넘어갈 때 tab 초기값 수정
- [x] 여행기 썸네일 센터로 수정

# 📸 스크린샷

<img width="471" alt="image" src="https://github.com/user-attachments/assets/c0d9e257-6588-48dc-85d3-8753bb0fc23c">

- 여행지 사진에서 캐러셀이 아닌 이미지가 한장일 때 image error 처리 누락된 부분 추가


<img width="478" alt="image" src="https://github.com/user-attachments/assets/d3f49575-426c-4a4c-ab4f-38a259483889">

- 여행기 상세보기 페이지에서 썸네일 이미지가 가운데가 아닌 윗부분에 맞춰지게 되있던것 수정

# 🙈 참고 사항

### 마이 페이지에서 사용되는 Tab 구현하고자 했던것

1. tab을 선택하고 새로고침해도 선택된 tab이 유지되어야함
2. 하지만 다른 페이지로 이동할 경우  첫번 째 tab이 선택되어있어야함
3. 내 여행기를 삭제하고 마이페이지로 돌아갈 경우에는 마이페이지의 tab은 두번째 탭 (내 여행기) 이 선택되어있어함
 -  그 이후 동작은 1~3 반복

많은 방법을 시도했봤지만, 결국 storage key를 1개로 유지하며 위 1~3 동작을 깔끔한 코드로 구현하기 어렵다고봤습니다.

MyPage의 Tab은 로컬스토리지에서 따로 관리하여 해결했습니다
