### PR TITLE
[Feature] - refresh token 클라이언트 내 적용

### DIFF
--- a/frontend/src/apis/client.ts
+++ b/frontend/src/apis/client.ts
@@ -10,7 +10,7 @@ export const authClient = axios.create({
   baseURL: process.env.REACT_APP_BASE_URL,
 });
 
-authClient.interceptors.request.use(handlePreviousRequest, handleAPIError);
+authClient.interceptors.request.use(handlePreviousRequest);
 authClient.interceptors.response.use((response) => response, handleAPIError);
 
 client.interceptors.response.use((response) => response, handleAPIError);

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -34,7 +34,7 @@ const Header = () => {
       navigate(ROUTE_PATHS_MAP.login);
     }
 
-    saveUser({ accessToken: "", memberId: 0 });
+    saveUser({ accessToken: "", memberId: 0, refreshToken: "" });
   };
 
   const handleClickMyPage = () => navigate(ROUTE_PATHS_MAP.my);

--- a/frontend/src/components/pages/login/KakaoCallbackPage.tsx
+++ b/frontend/src/components/pages/login/KakaoCallbackPage.tsx
@@ -1,6 +1,10 @@
 import { useContext, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { AxiosResponse } from "axios";
+
+import { AuthTokenResponse } from "@type/domain/user";
+
 import { client } from "@apis/client";
 
 import { SaveUserContext } from "@contexts/UserProvider";
@@ -24,8 +28,12 @@ const KakaoCallbackPage = () => {
     if (code) {
       client
         .post(API_ENDPOINT_MAP.loginOauth(code, encodedRedirectUri))
-        .then((res) => {
-          saveUser({ accessToken: res.data.accessToken, memberId: res.data.memberId });
+        .then((res: AxiosResponse<AuthTokenResponse>) => {
+          saveUser({
+            accessToken: res.data.accessToken,
+            memberId: res.data.memberId,
+            refreshToken: res.data.refreshToken,
+          });
           navigate(ROUTE_PATHS_MAP.root);
         })
         .catch(() => {

--- a/frontend/src/constants/endpoint.ts
+++ b/frontend/src/constants/endpoint.ts
@@ -10,4 +10,5 @@ export const API_ENDPOINT_MAP = {
   profile: "/member/me/profile",
   myTravelogues: "/member/me/travelogues",
   myTravelPlans: "/member/me/travel-plans",
+  reissueToken: "/login/reissue-token",
 } as const;

--- a/frontend/src/types/domain/user.ts
+++ b/frontend/src/types/domain/user.ts
@@ -1,5 +1,6 @@
 export interface AuthTokenResponse {
   accessToken: string;
+  refreshToken: string;
   memberId: number;
 }
 


### PR DESCRIPTION
# ✅ 작업 내용
- 서버로 부터 받은 refresh token을 로컬 스토리지에 저장
- access token이 만료 시 access token 재발급 로직 추가
- 리프레시 토큰이 만료될 경우 로그인 페이지로 리다이렉팅 하는 로직 추가

# 📸 스크린샷
x

# 🙈 참고 사항
- AuthTokenResponse에 refreshToken 필드를 추가했습니다.
- 많은 이슈들이 있었는데 백로그에 기록해두었습니다.
  - 인증 & 인가 관련해서도 tech log에 추가해두었으니 참고하시면 좋을듯해요~! 
