### PR TITLE
[Feature] - 여행기 장소 이미지 업로드 중일 경우, spinner를 보여주도록 리팩터링

### DIFF
--- a/frontend/src/components/common/MultiImageUpload/MultiImageUpload.stories.tsx
+++ b/frontend/src/components/common/MultiImageUpload/MultiImageUpload.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    previewUrls: [],
+    previewImageStates: [],
     fileInputRef: React.createRef(),
     onImageChange: () => {},
     onDeleteImage: () => {},
@@ -35,18 +35,21 @@ export const Default: Story = {
 export const WithImages: Story = {
   args: {
     ...Default.args,
-    previewUrls: [
-      "https://example.com/image1.jpg",
-      "https://example.com/image2.jpg",
-      "https://example.com/image3.jpg",
+    previewImageStates: [
+      { url: "https://example.com/image1.jpg", isLoading: false },
+      { url: "https://example.com/image2.jpg", isLoading: false },
+      { url: "https://example.com/image3.jpg", isLoading: false },
     ],
   },
 };
 
-export const WithManyImages: Story = {
+export const WithLoadingImages: Story = {
   args: {
     ...Default.args,
-    previewUrls: Array(7).fill("https://example.com/image.jpg"),
+    previewImageStates: Array.from({ length: 3 }, (_, index) => ({
+      url: `https://example.com/image${index}.jpg`,
+      isLoading: true,
+    })),
   },
 };
 

--- a/frontend/src/components/common/MultiImageUpload/MultiImageUpload.styled.ts
+++ b/frontend/src/components/common/MultiImageUpload/MultiImageUpload.styled.ts
@@ -1,5 +1,7 @@
 import styled from "@emotion/styled";
 
+import { PRIMITIVE_COLORS } from "@styles/tokens";
+
 export const MultiImageUploadContainer = styled.div`
   display: flex;
   justify-content: flex-start;
@@ -91,14 +93,14 @@ export const MultiImageUploadDeleteButton = styled.button`
   justify-content: center;
   align-items: center;
   position: absolute;
-  top: -1rem;
+  top: -0.6rem;
   right: -1rem;
   width: 2rem;
   height: 2rem;
   border: 1px solid ${(props) => props.theme.colors.border};
   border-radius: 50%;
 
-  background-color: #fff;
+  background-color: ${PRIMITIVE_COLORS.white};
 
   svg {
     width: 0.8rem;

--- a/frontend/src/components/common/MultiImageUpload/MultiImageUpload.tsx
+++ b/frontend/src/components/common/MultiImageUpload/MultiImageUpload.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import Spinner from "@components/common/Spinner/Spinner";
+
 import { useDragScroll } from "@hooks/index";
 
 import * as S from "./MultiImageUpload.styled";
@@ -7,7 +9,7 @@ import * as S from "./MultiImageUpload.styled";
 const MAX_PICTURES_COUNT = 10;
 
 interface MultiImageUploadProps extends React.ComponentPropsWithoutRef<"div"> {
-  previewUrls: string[];
+  previewImageStates: { url: string; isLoading: boolean }[];
   fileInputRef: React.RefObject<HTMLInputElement>;
   onImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onDeleteImage: (index: number) => void;
@@ -15,16 +17,45 @@ interface MultiImageUploadProps extends React.ComponentPropsWithoutRef<"div"> {
 }
 
 const MultiImageUpload = ({
-  previewUrls,
+  previewImageStates,
   fileInputRef,
   onImageChange,
   onDeleteImage,
   onButtonClick,
   ...props
 }: MultiImageUploadProps) => {
+  console.log("previewImageStates", previewImageStates, previewImageStates.length);
   const { scrollRef, onMouseDown, onMouseUp, onMouseMove, isDragging } = useDragScroll();
 
-  const hasPictures = previewUrls.length !== 0;
+  const hasPictures = previewImageStates.length !== 0;
+
+  const renderImageOrSpinner = (imageState: { url: string; isLoading: boolean }, index: number) => (
+    <S.MultiImageUploadPictureWrapper key={index}>
+      <S.MultiImageUploadDeleteButton onClick={() => onDeleteImage(index)}>
+        <svg
+          width="11"
+          height="11"
+          viewBox="0 0 11 11"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1.1002 11L0 9.9L4.40079 5.5L0 1.1L1.1002 0L5.50098 4.4L9.90177 0L11.002 1.1L6.60118 5.5L11.002 9.9L9.90177 11L5.50098 6.6L1.1002 11Z"
+            fill="#616161"
+          />
+        </svg>
+      </S.MultiImageUploadDeleteButton>
+      {imageState.isLoading ? (
+        <Spinner variants="circle" size={40} />
+      ) : (
+        <S.MultiImageUploadPicture
+          src={imageState.url}
+          alt={`업로드된 이미지 ${index + 1}`}
+          draggable="false"
+        />
+      )}
+    </S.MultiImageUploadPictureWrapper>
+  );
 
   return (
     <S.MultiImageUploadContainer {...props}>
@@ -51,7 +82,7 @@ const MultiImageUpload = ({
             </S.MultiImageUploadSVGWrapper>
 
             <p>
-              {previewUrls.length} / {MAX_PICTURES_COUNT}
+              {previewImageStates.length} / {MAX_PICTURES_COUNT}
             </p>
           </S.MultiImageUploadPictureAddButton>
           <S.MultiImageUploadHiddenInput
@@ -72,29 +103,7 @@ const MultiImageUpload = ({
             onMouseLeave={onMouseUp}
             $isDragging={isDragging}
           >
-            {previewUrls.map((previewUrl, index) => (
-              <S.MultiImageUploadPictureWrapper key={previewUrl}>
-                <S.MultiImageUploadDeleteButton onClick={() => onDeleteImage(index)}>
-                  <svg
-                    width="11"
-                    height="11"
-                    viewBox="0 0 11 11"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M1.1002 11L0 9.9L4.40079 5.5L0 1.1L1.1002 0L5.50098 4.4L9.90177 0L11.002 1.1L6.60118 5.5L11.002 9.9L9.90177 11L5.50098 6.6L1.1002 11Z"
-                      fill="#616161"
-                    />
-                  </svg>
-                </S.MultiImageUploadDeleteButton>
-                <S.MultiImageUploadPicture
-                  src={previewUrl}
-                  alt={`업로드된 이미지 ${index + 1}`}
-                  draggable="false"
-                />
-              </S.MultiImageUploadPictureWrapper>
-            ))}
+            {previewImageStates.map((imageState, index) => renderImageOrSpinner(imageState, index))}
           </S.ImageScrollContainer>
         </S.MultiImageUploadPictureContainer>
       )}
@@ -138,7 +147,7 @@ const MultiImageUpload = ({
             </S.MultiImageUploadSVGWrapper>
 
             <p>
-              {previewUrls.length} / {MAX_PICTURES_COUNT}
+              {previewImageStates.length} / {MAX_PICTURES_COUNT}
             </p>
           </S.MultiImageUploadPictureAddButton>
           <S.MultiImageUploadHiddenInput

--- a/frontend/src/components/common/MultiImageUpload/MultiImageUpload.tsx
+++ b/frontend/src/components/common/MultiImageUpload/MultiImageUpload.tsx
@@ -24,7 +24,6 @@ const MultiImageUpload = ({
   onButtonClick,
   ...props
 }: MultiImageUploadProps) => {
-  console.log("previewImageStates", previewImageStates, previewImageStates.length);
   const { scrollRef, onMouseDown, onMouseUp, onMouseMove, isDragging } = useDragScroll();
 
   const hasPictures = previewImageStates.length !== 0;

--- a/frontend/src/components/common/Spinner/Spinner.stories.tsx
+++ b/frontend/src/components/common/Spinner/Spinner.stories.tsx
@@ -11,11 +11,32 @@ const meta = {
     viewport: {
       defaultViewport: "desktop",
     },
+    docs: {
+      description: {
+        component:
+          "두 가지 variants(tturi, circle)가 있는 Spinner 컴포넌트이며, tturi의 경우 size를 70~100 정도로 사용해야합니다.",
+      },
+    },
   },
+  argTypes: {
+    variants: {
+      options: ["tturi", "circle"],
+      control: "select",
+    },
+    size: {
+      control: "range",
+    },
+  },
+  tags: ["autodocs"],
 } satisfies Meta<typeof Spinner>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    variants: "tturi",
+    size: 100,
+  },
+};

--- a/frontend/src/components/common/Spinner/Spinner.styled.ts
+++ b/frontend/src/components/common/Spinner/Spinner.styled.ts
@@ -1,5 +1,10 @@
-import { keyframes } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
+
+import { SpinnerVariants } from "@components/common/Spinner/Spinner.type";
+
+import theme from "@styles/theme";
+import { PRIMITIVE_COLORS } from "@styles/tokens";
 
 const rotate = keyframes`
   from {
@@ -10,15 +15,32 @@ const rotate = keyframes`
   }
 `;
 
-export const Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
+const createSpinnerVariants = ($variants: SpinnerVariants, $size: number) => {
+  return {
+    tturi: css`
+      display: flex;
+      justify-content: center;
+      align-items: center;
 
-  svg {
-    width: 10rem;
-    height: 10rem;
+      svg {
+        width: ${$size / 10}rem;
+        height: ${$size / 10}rem;
 
-    animation: ${rotate} 0.5s linear infinite;
-  }
+        animation: ${rotate} 0.5s linear infinite;
+      }
+    `,
+    circle: css`
+      width: ${$size / 10}rem;
+      height: ${$size / 10}rem;
+      border: ${$size / 130}rem solid ${theme.colors.border};
+      border-top: ${$size / 130}rem solid ${PRIMITIVE_COLORS.blue[500]};
+      border-radius: 50%;
+
+      animation: ${rotate} 1s linear infinite;
+    `,
+  }[$variants];
+};
+
+export const LoadingSpinner = styled.div<{ $variants: SpinnerVariants; $size: number }>`
+  ${({ $variants, $size }) => createSpinnerVariants($variants, $size)}
 `;

--- a/frontend/src/components/common/Spinner/Spinner.tsx
+++ b/frontend/src/components/common/Spinner/Spinner.tsx
@@ -1,12 +1,19 @@
+import type { SpinnerVariants } from "@components/common/Spinner/Spinner.type";
+
 import { Tturi } from "@assets/svg";
 
 import * as S from "./Spinner.styled";
 
-const Spinner = () => {
+interface SpinnerProps {
+  variants?: SpinnerVariants;
+  size?: number;
+}
+
+const Spinner = ({ variants = "tturi", size = 100 }: SpinnerProps) => {
   return (
-    <S.Wrapper>
-      <Tturi />
-    </S.Wrapper>
+    <S.LoadingSpinner $size={size} $variants={variants}>
+      {variants === "tturi" && <Tturi />}
+    </S.LoadingSpinner>
   );
 };
 

--- a/frontend/src/components/common/Spinner/Spinner.type.ts
+++ b/frontend/src/components/common/Spinner/Spinner.type.ts
@@ -1,0 +1,1 @@
+export type SpinnerVariants = "tturi" | "circle";

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.constants.ts
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.constants.ts
@@ -1,0 +1,1 @@
+export const MAX_IMAGE_UPLOAD_COUNT = 10;

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
@@ -14,14 +14,7 @@ interface ImageState {
   isLoading: boolean;
 }
 
-const TravelogueMultiImageUpload = ({
-  dayIndex,
-  placeIndex,
-  imageUrls,
-  onRequestAddImage,
-  onChangeImageUrls,
-  onDeleteImageUrls,
-}: {
+interface TravelogueMultiImageUploadProps {
   imageUrls: string[];
   dayIndex: number;
   placeIndex: number;
@@ -31,7 +24,16 @@ const TravelogueMultiImageUpload = ({
   ) => Promise<string[]>;
   onChangeImageUrls: (dayIndex: number, placeIndex: number, imgUrls: string[]) => void;
   onDeleteImageUrls: (dayIndex: number, targetPlaceIndex: number, imageIndex: number) => void;
-}) => {
+}
+
+const TravelogueMultiImageUpload = ({
+  dayIndex,
+  placeIndex,
+  imageUrls,
+  onRequestAddImage,
+  onChangeImageUrls,
+  onDeleteImageUrls,
+}: TravelogueMultiImageUploadProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [imageStates, setImageStates] = useState<ImageState[]>(
     imageUrls.map((url) => ({ url, isLoading: false })),
@@ -59,9 +61,7 @@ const TravelogueMultiImageUpload = ({
         const updatedStates = [...prevStates];
         const startIndex = updatedStates.findIndex((state) => state.isLoading);
         newImageUrls.forEach((url, index) => {
-          if (startIndex + index < updatedStates.length) {
-            updatedStates[startIndex + index] = { url, isLoading: false };
-          }
+          updatedStates[startIndex + index] = { url, isLoading: false };
         });
         return updatedStates;
       });

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
@@ -69,6 +69,10 @@ const TravelogueMultiImageUpload = ({
       onChangeImageUrls(dayIndex, placeIndex, allImageUrls);
     } catch (error) {
       setImageStates((prevStates) => prevStates.slice(0, prevStates.length - files.length));
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
     }
   };
 

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
@@ -1,20 +1,11 @@
-import React, { useRef, useState } from "react";
-
 import { css } from "@emotion/react";
 
 import { MutateOptions } from "@tanstack/react-query";
 
 import { MultiImageUpload } from "@components/common";
-import { MAX_IMAGE_UPLOAD_COUNT } from "@components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.constants";
+import { useTravelogueMultiImageUpload } from "@components/pages/travelogueRegister/TravelogueMultiImageUpload/hooks/useMultiImageUpload";
 
-import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
-
-interface ImageState {
-  url: string;
-  isLoading: boolean;
-}
-
-interface TravelogueMultiImageUploadProps {
+export interface TravelogueMultiImageUploadProps {
   imageUrls: string[];
   dayIndex: number;
   placeIndex: number;
@@ -34,53 +25,15 @@ const TravelogueMultiImageUpload = ({
   onChangeImageUrls,
   onDeleteImageUrls,
 }: TravelogueMultiImageUploadProps) => {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [imageStates, setImageStates] = useState<ImageState[]>(
-    imageUrls.map((url) => ({ url, isLoading: false })),
-  );
-
-  const handleClickButton = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleChangeImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files as FileList);
-
-    if (imageStates.length + files.length > MAX_IMAGE_UPLOAD_COUNT) {
-      alert(ERROR_MESSAGE_MAP.imageUpload);
-      return;
-    }
-
-    const newImageStates = files.map(() => ({ url: "", isLoading: true }));
-    setImageStates((prevStates) => [...prevStates, ...newImageStates]);
-
-    try {
-      const newImageUrls = await onRequestAddImage(files);
-
-      setImageStates((prevStates) => {
-        const updatedStates = [...prevStates];
-        const startIndex = updatedStates.findIndex((state) => state.isLoading);
-        newImageUrls.forEach((url, index) => {
-          updatedStates[startIndex + index] = { url, isLoading: false };
-        });
-        return updatedStates;
-      });
-
-      const allImageUrls = [...imageUrls, ...newImageUrls];
-      onChangeImageUrls(dayIndex, placeIndex, allImageUrls);
-    } catch (error) {
-      setImageStates((prevStates) => prevStates.slice(0, prevStates.length - files.length));
-    } finally {
-      if (fileInputRef.current) {
-        fileInputRef.current.value = "";
-      }
-    }
-  };
-
-  const handleDeleteImage = (imageIndex: number) => {
-    setImageStates((prevStates) => prevStates.filter((_, index) => index !== imageIndex));
-    onDeleteImageUrls(dayIndex, placeIndex, imageIndex);
-  };
+  const { imageStates, fileInputRef, handleChangeImage, handleClickButton, handleDeleteImage } =
+    useTravelogueMultiImageUpload({
+      imageUrls,
+      dayIndex,
+      placeIndex,
+      onRequestAddImage,
+      onChangeImageUrls,
+      onDeleteImageUrls,
+    });
 
   return (
     <MultiImageUpload

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
@@ -5,6 +5,7 @@ import { css } from "@emotion/react";
 import { MutateOptions } from "@tanstack/react-query";
 
 import { MultiImageUpload } from "@components/common";
+import { MAX_IMAGE_UPLOAD_COUNT } from "@components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.constants";
 
 import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
 
@@ -36,14 +37,14 @@ const TravelogueMultiImageUpload = ({
     imageUrls.map((url) => ({ url, isLoading: false })),
   );
 
-  const handleButtonClick = () => {
+  const handleClickButton = () => {
     fileInputRef.current?.click();
   };
 
-  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files as FileList);
 
-    if (imageStates.length + files.length > 10) {
+    if (imageStates.length + files.length > MAX_IMAGE_UPLOAD_COUNT) {
       alert(ERROR_MESSAGE_MAP.imageUpload);
       return;
     }
@@ -85,9 +86,9 @@ const TravelogueMultiImageUpload = ({
     <MultiImageUpload
       previewImageStates={imageStates}
       fileInputRef={fileInputRef}
-      onImageChange={handleImageChange}
+      onImageChange={handleChangeImage}
       onDeleteImage={handleDeleteImage}
-      onButtonClick={handleButtonClick}
+      onButtonClick={handleClickButton}
       css={css`
         margin-bottom: 1.6rem;
       `}

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.tsx
@@ -53,12 +53,12 @@ const TravelogueMultiImageUpload = ({
     setImageStates((prevStates) => [...prevStates, ...newImageStates]);
 
     try {
-      const newImgUrls = await onRequestAddImage(files);
+      const newImageUrls = await onRequestAddImage(files);
 
       setImageStates((prevStates) => {
         const updatedStates = [...prevStates];
         const startIndex = updatedStates.findIndex((state) => state.isLoading);
-        newImgUrls.forEach((url, index) => {
+        newImageUrls.forEach((url, index) => {
           if (startIndex + index < updatedStates.length) {
             updatedStates[startIndex + index] = { url, isLoading: false };
           }
@@ -66,7 +66,7 @@ const TravelogueMultiImageUpload = ({
         return updatedStates;
       });
 
-      const allImageUrls = [...imageUrls, ...newImgUrls];
+      const allImageUrls = [...imageUrls, ...newImageUrls];
       onChangeImageUrls(dayIndex, placeIndex, allImageUrls);
     } catch (error) {
       setImageStates((prevStates) => prevStates.slice(0, prevStates.length - files.length));

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/hooks/useMultiImageUpload.ts
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/hooks/useMultiImageUpload.ts
@@ -1,0 +1,94 @@
+import React, { useRef, useState } from "react";
+
+import { TravelogueMultiImageUploadProps } from "@components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload";
+import { MAX_IMAGE_UPLOAD_COUNT } from "@components/pages/travelogueRegister/TravelogueMultiImageUpload/TravelogueMultiImageUpload.constants";
+
+import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
+
+interface ImageState {
+  url: string;
+  isLoading: boolean;
+}
+
+export const useTravelogueMultiImageUpload = ({
+  dayIndex,
+  placeIndex,
+  imageUrls,
+  onRequestAddImage,
+  onChangeImageUrls,
+  onDeleteImageUrls,
+}: TravelogueMultiImageUploadProps) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [imageStates, setImageStates] = useState<ImageState[]>(
+    imageUrls.map((url) => ({ url, isLoading: false })),
+  );
+
+  const handleClickButton = () => {
+    fileInputRef.current?.click();
+  };
+
+  const addLoadingImageStates = (files: File[]) => {
+    const newImageStates = files.map(() => ({ url: "", isLoading: true }));
+    setImageStates((prevStates) => [...prevStates, ...newImageStates]);
+  };
+
+  const updateImageStates = (newUrls: string[]) => {
+    setImageStates((prevStates) => {
+      const updatedStates = [...prevStates];
+      const startIndex = updatedStates.findIndex((state) => state.isLoading);
+      newUrls.forEach((url, index) => {
+        updatedStates[startIndex + index] = { url, isLoading: false };
+      });
+      return updatedStates;
+    });
+  };
+
+  const handleUploadSuccess = (newUrls: string[]) => {
+    updateImageStates(newUrls);
+    const allImageUrls = [...imageUrls, ...newUrls];
+    onChangeImageUrls(dayIndex, placeIndex, allImageUrls);
+  };
+
+  const revertImageStates = (failedCount: number) => {
+    setImageStates((prevStates) => prevStates.slice(0, prevStates.length - failedCount));
+  };
+
+  const resetFileInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleChangeImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files as FileList);
+
+    if (imageStates.length + files.length > MAX_IMAGE_UPLOAD_COUNT) {
+      alert(ERROR_MESSAGE_MAP.imageUpload);
+      return;
+    }
+
+    addLoadingImageStates(files);
+
+    try {
+      const newImageUrls = await onRequestAddImage(files);
+      handleUploadSuccess(newImageUrls);
+    } catch (error) {
+      revertImageStates(files.length);
+    } finally {
+      resetFileInput();
+    }
+  };
+
+  const handleDeleteImage = (imageIndex: number) => {
+    setImageStates((prevStates) => prevStates.filter((_, index) => index !== imageIndex));
+    onDeleteImageUrls(dayIndex, placeIndex, imageIndex);
+  };
+
+  return {
+    imageStates,
+    fileInputRef,
+    handleChangeImage,
+    handleDeleteImage,
+    handleClickButton,
+  };
+};

--- a/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/hooks/useMultiImageUpload.ts
+++ b/frontend/src/components/pages/travelogueRegister/TravelogueMultiImageUpload/hooks/useMultiImageUpload.ts
@@ -19,7 +19,7 @@ export const useTravelogueMultiImageUpload = ({
   onDeleteImageUrls,
 }: TravelogueMultiImageUploadProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [imageStates, setImageStates] = useState<ImageState[]>(
+  const [imageStates, setImageStates] = useState<ImageState[]>(() =>
     imageUrls.map((url) => ({ url, isLoading: false })),
   );
 


### PR DESCRIPTION
# ✅ 작업 내용
- Spinner 내 variants 및 size prop 추가 및 리팩터링
  - 스토리북 추가 완료!
- MultiImageUpload 컴포넌트 내 image upload 중일 시 spinner를 렌더링 시키도록 변경 
- TravelogueMultiImageUpload 내 로딩 처리 완료
  - 각 이미지 파일에 대한 개별 로딩 상태 관리 구현
  - 업로드 요청 시작 시 해당 이미지의 로딩 상태를 true로 설정
  - 업로드 완료 또는 실패 시 로딩 상태를 false로 변경

# 📸 스크린샷
https://github.com/user-attachments/assets/cd505ce6-229a-4e17-be78-4de5e2ede881



# 🙈 참고 사항
- Spinner 컴포넌트 확인해주시면 좋을거 같슴다
- MultiImageUpload 스토리북 내에서 렉걸리던데, 그냥 스토리 지워버릴까 고민되는 부분입니다,,