### PR TITLE
[Feature] - 좋아요 기능 구현

### DIFF
--- a/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
@@ -49,7 +49,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (token == null || token.isBlank()) {
+        if (isTokenBlank(token)) {
             sendUnauthorizedResponse(response, "로그인을 해주세요.");
             return;
         }
@@ -79,14 +79,21 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String method = request.getMethod();
+        String requestURI = request.getRequestURI();
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        return isInWhiteList(method, requestURI) && isTokenBlank(token);
+    }
+
+    private boolean isInWhiteList(String method, String url) {
         AntPathMatcher antPathMatcher = new AntPathMatcher();
 
-        String url = request.getRequestURI();
-        String method = request.getMethod();
-
         return WHITE_LIST.stream()
-                .anyMatch(white -> white.method().matches(method) && antPathMatcher.match(white.urlPattern(), url))
-                && (token == null || token.isBlank());
+                .anyMatch(white -> white.method().matches(method) && antPathMatcher.match(white.urlPattern(), url));
+    }
+
+    private boolean isTokenBlank(String token) {
+        return token == null || token.isBlank();
     }
 }

--- a/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
+++ b/backend/src/main/java/kr/touroot/global/auth/JwtAuthFilter.java
@@ -79,12 +79,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
         AntPathMatcher antPathMatcher = new AntPathMatcher();
 
         String url = request.getRequestURI();
         String method = request.getMethod();
 
         return WHITE_LIST.stream()
-                .anyMatch(white -> white.method().matches(method) && antPathMatcher.match(white.urlPattern(), url));
+                .anyMatch(white -> white.method().matches(method) && antPathMatcher.match(white.urlPattern(), url))
+                && (token == null || token.isBlank());
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -79,7 +79,7 @@ public class TravelogueController {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "로그인하지 않은 사용자가 생성을 시도할 때",
+                    description = "로그인하지 않은 사용자가 좋아요를 할 때",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             ),
     })

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -85,7 +85,6 @@ public class TravelogueController {
     })
     @PostMapping("/{id}/like")
     public ResponseEntity<TravelogueLikeResponse> likeTravelogue(@PathVariable Long id, @Valid MemberAuth member) {
-
         return ResponseEntity.ok()
                 .body(travelogueFacadeService.likeTravelogue(id, member));
     }
@@ -224,5 +223,28 @@ public class TravelogueController {
         travelogueFacadeService.deleteTravelogueById(id, memberAuth);
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @Operation(summary = "여행기 좋아요 취소")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 여행기 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 사용자가 좋아요를 취소 할 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+    })
+    @DeleteMapping("/{id}/like")
+    public ResponseEntity<TravelogueLikeResponse> dislikeTravelogue(@PathVariable Long id, @Valid MemberAuth member) {
+        return ResponseEntity.ok()
+                .body(travelogueFacadeService.unlikeTravelogue(id, member));
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -261,7 +261,7 @@ public class TravelogueController {
             ),
     })
     @DeleteMapping("/{id}/like")
-    public ResponseEntity<TravelogueLikeResponse> dislikeTravelogue(@PathVariable Long id, @Valid MemberAuth member) {
+    public ResponseEntity<TravelogueLikeResponse> unlikeTravelogue(@PathVariable Long id, @Valid MemberAuth member) {
         return ResponseEntity.ok()
                 .body(travelogueFacadeService.unlikeTravelogue(id, member));
     }

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -104,6 +105,23 @@ public class TravelogueController {
     @GetMapping("/{id}")
     public ResponseEntity<TravelogueResponse> findTravelogue(@PathVariable Long id) {
         return ResponseEntity.ok(travelogueFacadeService.findTravelogueById(id));
+    }
+
+    @Operation(summary = "여행기 상세 조회")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 여행기 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+    })
+    @GetMapping(value = "/{id}", headers = {HttpHeaders.AUTHORIZATION})
+    public ResponseEntity<TravelogueResponse> findTravelogue(@PathVariable Long id, MemberAuth member) {
+        return ResponseEntity.ok(travelogueFacadeService.findTravelogueById(id, member));
     }
 
     @Operation(summary = "여행기 메인 페이지 조회")

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -14,6 +14,7 @@ import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.dto.ExceptionResponse;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
+import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
 import kr.touroot.travelogue.dto.response.TravelogueResponse;
 import kr.touroot.travelogue.dto.response.TravelogueSimpleResponse;
 import kr.touroot.travelogue.service.TravelogueFacadeService;
@@ -63,6 +64,30 @@ public class TravelogueController {
 
         return ResponseEntity.created(URI.create("/api/v1/travelogues/" + response.id()))
                 .body(response);
+    }
+
+    @Operation(summary = "여행기 좋아요")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "존재하지 않는 여행기 ID로 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인하지 않은 사용자가 생성을 시도할 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+    })
+    @PostMapping("/{id}/like")
+    public ResponseEntity<TravelogueLikeResponse> likeTravelogue(@PathVariable Long id, @Valid MemberAuth member) {
+
+        return ResponseEntity.ok()
+                .body(travelogueFacadeService.likeTravelogue(id, member));
     }
 
     @Operation(summary = "여행기 상세 조회")

--- a/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueLike.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueLike.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import kr.touroot.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"travelogue", "liker"})})
 @Entity
 public class TravelogueLike {
 

--- a/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueLike.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueLike.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"travelogue", "liker"})})
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"TRAVELOGUE_ID", "LIKER_ID"})})
 @Entity
 public class TravelogueLike {
 

--- a/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueLike.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/TravelogueLike.java
@@ -1,0 +1,37 @@
+package kr.touroot.travelogue.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.touroot.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class TravelogueLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "TRAVELOGUE_ID", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Travelogue travelogue;
+
+    @JoinColumn(name = "LIKER_ID", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member liker;
+
+    public TravelogueLike(Travelogue travelogue, Member liker) {
+        this(null, travelogue, liker);
+    }
+}

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueLikeResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueLikeResponse.java
@@ -1,0 +1,11 @@
+package kr.touroot.travelogue.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TravelogueLikeResponse(
+        @Schema(description = "로그인한 사용자의 좋아요 여부", example = "true")
+        Boolean isLiked,
+        @Schema(description = "여행기의 좋아요 수", example = "10")
+        Long likeCount
+) {
+}

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueLikeResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueLikeResponse.java
@@ -3,7 +3,7 @@ package kr.touroot.travelogue.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TravelogueLikeResponse(
-        @Schema(description = "로그인한 사용자의 좋아요 여부", example = "true")
+        @Schema(description = "사용자의 좋아요 여부", example = "true")
         Boolean isLiked,
         @Schema(description = "여행기의 좋아요 수", example = "10")
         Long likeCount

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
@@ -26,10 +26,18 @@ public record TravelogueResponse(
         @Schema(description = "여행기 태그")
         List<TagResponse> tags,
         @Schema(description = "여행기 일자 목록")
-        List<TravelogueDayResponse> days
+        List<TravelogueDayResponse> days,
+        @Schema(description = "여행기 좋아요 숫자", example = "10")
+        Long likeCount,
+        @Schema(description = "여행기 좋아요 여부", example = "true")
+        Boolean isLiked
 ) {
 
-    public static TravelogueResponse of(Travelogue travelogue, List<TravelogueDayResponse> days, List<TagResponse> tags) {
+    public static TravelogueResponse of(
+            Travelogue travelogue,
+            List<TravelogueDayResponse> days,
+            List<TagResponse> tags,
+            TravelogueLikeResponse like) {
         return TravelogueResponse.builder()
                 .id(travelogue.getId())
                 .createdAt(travelogue.getCreatedAt().toLocalDate())
@@ -40,6 +48,8 @@ public record TravelogueResponse(
                 .thumbnail(travelogue.getThumbnail())
                 .days(days)
                 .tags(tags)
+                .likeCount(like.likeCount())
+                .isLiked(like.isLiked())
                 .build();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueResponse.java
@@ -29,7 +29,7 @@ public record TravelogueResponse(
         List<TravelogueDayResponse> days,
         @Schema(description = "여행기 좋아요 숫자", example = "10")
         Long likeCount,
-        @Schema(description = "여행기 좋아요 여부", example = "true")
+        @Schema(description = "사용자의 여행기 좋아요 여부", example = "true")
         Boolean isLiked
 ) {
 

--- a/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueSimpleResponse.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/response/TravelogueSimpleResponse.java
@@ -19,10 +19,15 @@ public record TravelogueSimpleResponse(
         @Schema(description = "작성자 프로필 사진 URL", example = "https://dev.touroot.kr/images/profile.png")
         String authorProfileUrl,
         @Schema(description = "여행기 태그 목록")
-        List<TagResponse> tags
+        List<TagResponse> tags,
+        @Schema(description = "작성자 프로필 사진 URL", example = "10")
+        Long likeCount
 ) {
 
-    public static TravelogueSimpleResponse of(Travelogue travelogue, List<TagResponse> tags) {
+    public static TravelogueSimpleResponse of(
+            Travelogue travelogue,
+            List<TagResponse> tags,
+            TravelogueLikeResponse like) {
         return TravelogueSimpleResponse.builder()
                 .id(travelogue.getId())
                 .title(travelogue.getTitle())
@@ -30,6 +35,7 @@ public record TravelogueSimpleResponse(
                 .authorNickname(travelogue.getAuthorNickname())
                 .authorProfileUrl(travelogue.getAuthorProfileImageUrl())
                 .tags(tags)
+                .likeCount(like.likeCount())
                 .build();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
@@ -6,6 +6,7 @@ import kr.touroot.travelogue.domain.TravelogueLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelogueLikeRepository extends JpaRepository<TravelogueLike, Long> {
+
     Long countByTravelogue(Travelogue travelogue);
 
     boolean existsByTravelogueAndLiker(Travelogue travelogue, Member liker);

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
@@ -1,0 +1,9 @@
+package kr.touroot.travelogue.repository;
+
+import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.domain.TravelogueLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelogueLikeRepository extends JpaRepository<TravelogueLike, Long> {
+    Long countByTravelogue(Travelogue travelogue);
+}

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
@@ -1,9 +1,14 @@
 package kr.touroot.travelogue.repository;
 
+import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelogueLikeRepository extends JpaRepository<TravelogueLike, Long> {
     Long countByTravelogue(Travelogue travelogue);
+
+    boolean existsByTravelogueAndLiker(Travelogue travelogue, Member liker);
+
+    void deleteByTravelogueAndLiker(Travelogue travelogue, Member liker);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -73,6 +73,7 @@ public class TravelogueFacadeService {
                 .toList();
     }
 
+    @Transactional
     public TravelogueLikeResponse likeTravelogue(Long travelogueId, MemberAuth member) {
         Travelogue travelogue = travelogueService.getTravelogueById(travelogueId);
         Member liker = memberService.getById(member.memberId());

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -166,4 +166,12 @@ public class TravelogueFacadeService {
         clearTravelogueContents(travelogue);
         travelogueService.delete(travelogue, author);
     }
+
+    @Transactional
+    public TravelogueLikeResponse unlikeTravelogue(Long travelogueId, MemberAuth member) {
+        Travelogue travelogue = travelogueService.getTravelogueById(travelogueId);
+        Member liker = memberService.getById(member.memberId());
+
+        return travelogueLikeService.unlikeTravelogue(travelogue, liker);
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -151,7 +151,8 @@ public class TravelogueFacadeService {
 
     private TravelogueSimpleResponse getTravelogueSimpleResponse(Travelogue travelogue) {
         List<TagResponse> tagResponses = travelogueTagService.readTagByTravelogue(travelogue);
-        return TravelogueSimpleResponse.of(travelogue, tagResponses);
+        TravelogueLikeResponse likeResponse = travelogueLikeService.findLikeByTravelogue(travelogue);
+        return TravelogueSimpleResponse.of(travelogue, tagResponses, likeResponse);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -17,6 +17,7 @@ import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
 import kr.touroot.travelogue.dto.response.TravelogueDayResponse;
+import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
 import kr.touroot.travelogue.dto.response.TraveloguePlaceResponse;
 import kr.touroot.travelogue.dto.response.TravelogueResponse;
 import kr.touroot.travelogue.dto.response.TravelogueSimpleResponse;
@@ -35,6 +36,7 @@ public class TravelogueFacadeService {
     private final TraveloguePlaceService traveloguePlaceService;
     private final TraveloguePhotoService traveloguePhotoService;
     private final TravelogueTagService travelogueTagService;
+    private final TravelogueLikeService travelogueLikeService;
     private final MemberService memberService;
 
     @Transactional
@@ -69,6 +71,13 @@ public class TravelogueFacadeService {
         return photos.stream()
                 .map(TraveloguePhoto::getKey)
                 .toList();
+    }
+
+    public TravelogueLikeResponse likeTravelogue(Long travelogueId, MemberAuth member) {
+        Travelogue travelogue = travelogueService.getTravelogueById(travelogueId);
+        Member liker = memberService.getById(member.memberId());
+
+        return travelogueLikeService.likeTravelogue(travelogue, liker);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -15,6 +15,17 @@ public class TravelogueLikeService {
 
     private final TravelogueLikeRepository travelogueLikeRepository;
 
+    @Transactional(readOnly = true)
+    public TravelogueLikeResponse findLikeByTravelogue(Travelogue travelogue) {
+        return new TravelogueLikeResponse(false, travelogueLikeRepository.countByTravelogue(travelogue));
+    }
+
+    @Transactional(readOnly = true)
+    public TravelogueLikeResponse findLikeByTravelogueAndLiker(Travelogue travelogue, Member liker) {
+        boolean exists = travelogueLikeRepository.existsByTravelogueAndLiker(travelogue, liker);
+        return new TravelogueLikeResponse(exists, travelogueLikeRepository.countByTravelogue(travelogue));
+    }
+
     @Transactional
     public TravelogueLikeResponse likeTravelogue(Travelogue travelogue, Member liker) {
         boolean notExists = !travelogueLikeRepository.existsByTravelogueAndLiker(travelogue, liker);

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -7,6 +7,7 @@ import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
 import kr.touroot.travelogue.repository.TravelogueLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -14,6 +15,7 @@ public class TravelogueLikeService {
 
     private final TravelogueLikeRepository travelogueLikeRepository;
 
+    @Transactional
     public TravelogueLikeResponse likeTravelogue(Travelogue travelogue, Member liker) {
         TravelogueLike travelogueLike = new TravelogueLike(travelogue, liker);
         travelogueLikeRepository.save(travelogueLike);

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -17,9 +17,22 @@ public class TravelogueLikeService {
 
     @Transactional
     public TravelogueLikeResponse likeTravelogue(Travelogue travelogue, Member liker) {
-        TravelogueLike travelogueLike = new TravelogueLike(travelogue, liker);
-        travelogueLikeRepository.save(travelogueLike);
+        boolean notExists = !travelogueLikeRepository.existsByTravelogueAndLiker(travelogue, liker);
+        if (notExists) {
+            TravelogueLike travelogueLike = new TravelogueLike(travelogue, liker);
+            travelogueLikeRepository.save(travelogueLike);
+        }
 
         return new TravelogueLikeResponse(true, travelogueLikeRepository.countByTravelogue(travelogue));
+    }
+
+    @Transactional
+    public TravelogueLikeResponse unlikeTravelogue(Travelogue travelogue, Member liker) {
+        boolean exists = travelogueLikeRepository.existsByTravelogueAndLiker(travelogue, liker);
+        if (exists) {
+            travelogueLikeRepository.deleteByTravelogueAndLiker(travelogue, liker);
+        }
+
+        return new TravelogueLikeResponse(false, travelogueLikeRepository.countByTravelogue(travelogue));
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -1,0 +1,23 @@
+package kr.touroot.travelogue.service;
+
+import kr.touroot.member.domain.Member;
+import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.domain.TravelogueLike;
+import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
+import kr.touroot.travelogue.repository.TravelogueLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TravelogueLikeService {
+
+    private final TravelogueLikeRepository travelogueLikeRepository;
+
+    public TravelogueLikeResponse likeTravelogue(Travelogue travelogue, Member liker) {
+        TravelogueLike travelogueLike = new TravelogueLike(travelogue, liker);
+        travelogueLikeRepository.save(travelogueLike);
+
+        return new TravelogueLikeResponse(true, travelogueLikeRepository.countByTravelogue(travelogue));
+    }
+}

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -476,4 +476,40 @@ class TravelogueControllerTest {
                 .statusCode(403)
                 .body("message", is("본인이 작성한 여행기만 수정하거나 삭제할 수 있습니다."));
     }
+
+    @DisplayName("여행기에 좋아요 취소를 한다.")
+    @Test
+    void unlikeTravelogue() throws JsonProcessingException {
+        testHelper.initTravelogueTestDataWithLike(member);
+        TravelogueLikeResponse response = new TravelogueLikeResponse(false, 0L);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travelogues/1/like")
+                .then().log().all()
+                .statusCode(200).assertThat()
+                .body(is(objectMapper.writeValueAsString(response)));
+    }
+
+    @DisplayName("존재하지 않는 여행기에 좋아요 취소를 하면 예외가 발생한다.")
+    @Test
+    void unlikeTravelogueWithNotExistThrowException() throws JsonProcessingException {
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("/api/v1/travelogues/1/like")
+                .then().log().all()
+                .statusCode(400).assertThat()
+                .body("message", is("존재하지 않는 여행기입니다."));
+    }
+
+    @DisplayName("여행기 좋아요 취소를 할 때 로그인 되어 있지 않으면 예외가 발생한다.")
+    @Test
+    void unlikeTravelogueWithNotLoginThrowException() {
+        testHelper.initTravelogueTestDataWithLike(member);
+
+        RestAssured.given().log().all()
+                .when().delete("/api/v1/travelogues/1/like")
+                .then().log().all()
+                .statusCode(401);
+    }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -206,7 +206,8 @@ class TravelogueControllerTest {
                 .body(request)
                 .when().post("/api/v1/travelogues")
                 .then().log().all()
-                .statusCode(401);
+                .statusCode(401)
+                .body("message", is("로그인을 해주세요."));
     }
 
     @DisplayName("여행기에 좋아요를 한다.")
@@ -244,7 +245,8 @@ class TravelogueControllerTest {
         RestAssured.given().log().all()
                 .when().post("/api/v1/travelogues/1/like")
                 .then().log().all()
-                .statusCode(401);
+                .statusCode(401)
+                .body("message", is("로그인을 해주세요."));
     }
 
     @DisplayName("여행기를 상세 조회한다.")
@@ -525,6 +527,7 @@ class TravelogueControllerTest {
         RestAssured.given().log().all()
                 .when().delete("/api/v1/travelogues/1/like")
                 .then().log().all()
-                .statusCode(401);
+                .statusCode(401)
+                .body("message", is("로그인을 해주세요."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -261,6 +261,21 @@ class TravelogueControllerTest {
                 .body(is(objectMapper.writeValueAsString(response)));
     }
 
+    @DisplayName("여행기에 좋아요를 누른 사용자가 여행기를 상세 조회한다.")
+    @Test
+    void findTravelogueWithLike() throws JsonProcessingException {
+        testHelper.initTravelogueTestDataWithLike(member);
+        TravelogueResponse response = TravelogueResponseFixture.getTravelogueResponseWithLike();
+
+        RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("/api/v1/travelogues/1")
+                .then().log().all()
+                .statusCode(200).assertThat()
+                .body(is(objectMapper.writeValueAsString(response)));
+    }
+
     @DisplayName("태그가 있는 여행기를 상세 조회한다.")
     @Test
     void findTravelogueWithTags() throws JsonProcessingException {

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -20,6 +20,7 @@ import kr.touroot.travelogue.dto.request.TravelogueDayRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
+import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
 import kr.touroot.travelogue.dto.response.TravelogueResponse;
 import kr.touroot.travelogue.dto.response.TravelogueSimpleResponse;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
@@ -204,6 +205,44 @@ class TravelogueControllerTest {
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when().post("/api/v1/travelogues")
+                .then().log().all()
+                .statusCode(401);
+    }
+
+    @DisplayName("여행기에 좋아요를 한다.")
+    @Test
+    void likeTravelogue() throws JsonProcessingException {
+        Member author = testHelper.initKakaoMemberTestData();
+        testHelper.initTravelogueTestData(author);
+        TravelogueLikeResponse response = new TravelogueLikeResponse(true, 1L);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().post("/api/v1/travelogues/1/like")
+                .then().log().all()
+                .statusCode(200).assertThat()
+                .body(is(objectMapper.writeValueAsString(response)));
+    }
+
+    @DisplayName("존재하지 않는 여행기에 좋아요를 하면 예외가 발생한다.")
+    @Test
+    void likeTravelogueWithNotExistThrowException() throws JsonProcessingException {
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().post("/api/v1/travelogues/1/like")
+                .then().log().all()
+                .statusCode(400).assertThat()
+                .body("message", is("존재하지 않는 여행기입니다."));
+    }
+
+    @DisplayName("여행기를 좋아요 할 때 로그인 되어 있지 않으면 예외가 발생한다.")
+    @Test
+    void likeTravelogueWithNotLoginThrowException() {
+        Member author = testHelper.initKakaoMemberTestData();
+        testHelper.initTravelogueTestData(author);
+
+        RestAssured.given().log().all()
+                .when().post("/api/v1/travelogues/1/like")
                 .then().log().all()
                 .statusCode(401);
     }

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
@@ -32,6 +32,8 @@ public class TravelogueResponseFixture {
                 .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                 .days(getTravelogueDayResponses())
                 .tags(List.of())
+                .isLiked(false)
+                .likeCount(0L)
                 .build();
     }
 
@@ -46,6 +48,8 @@ public class TravelogueResponseFixture {
                 .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail_2.png")
                 .days(getUpdatedTravelogueDayResponses())
                 .tags(List.of())
+                .isLiked(false)
+                .likeCount(0L)
                 .build();
     }
 
@@ -60,6 +64,24 @@ public class TravelogueResponseFixture {
                 .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                 .days(getTravelogueDayResponses())
                 .tags(List.of(TagFixture.TAG_1.getResponse(1L)))
+                .likeCount(0L)
+                .isLiked(false)
+                .build();
+    }
+
+    public static TravelogueResponse getTravelogueResponseWithLike() {
+        return TravelogueResponse.builder()
+                .id(1L)
+                .title("제주에 하영 옵서")
+                .createdAt(LocalDate.now())
+                .authorNickname("리비")
+                .authorId(2L)
+                .authorProfileImageUrl("https://dev.touroot.kr/temporary/profile.png")
+                .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
+                .days(getTravelogueDayResponses())
+                .tags(List.of())
+                .isLiked(true)
+                .likeCount(1L)
                 .build();
     }
 

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
@@ -94,6 +94,7 @@ public class TravelogueResponseFixture {
                         .authorProfileUrl("https://dev.touroot.kr/temporary/profile.png")
                         .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                         .tags(List.of(TagFixture.TAG_1.getResponse(1L)))
+                        .likeCount(0L)
                         .build(),
                 TravelogueSimpleResponse.builder()
                         .id(1L)
@@ -102,6 +103,7 @@ public class TravelogueResponseFixture {
                         .authorProfileUrl("https://dev.touroot.kr/temporary/profile.png")
                         .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
                         .tags(List.of())
+                        .likeCount(1L)
                         .build()
         );
 

--- a/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
@@ -18,10 +18,12 @@ import kr.touroot.tag.fixture.TagFixture;
 import kr.touroot.tag.repository.TagRepository;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueDay;
+import kr.touroot.travelogue.domain.TravelogueLike;
 import kr.touroot.travelogue.domain.TraveloguePhoto;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import kr.touroot.travelogue.domain.TravelogueTag;
 import kr.touroot.travelogue.repository.TravelogueDayRepository;
+import kr.touroot.travelogue.repository.TravelogueLikeRepository;
 import kr.touroot.travelogue.repository.TraveloguePhotoRepository;
 import kr.touroot.travelogue.repository.TraveloguePlaceRepository;
 import kr.touroot.travelogue.repository.TravelogueRepository;
@@ -40,6 +42,7 @@ public class TravelogueTestHelper {
     private final MemberRepository memberRepository;
     private final TagRepository tagRepository;
     private final TravelogueTagRepository travelogueTagRepository;
+    private final TravelogueLikeRepository travelogueLikeRepository;
 
     @Autowired
     public TravelogueTestHelper(
@@ -50,7 +53,8 @@ public class TravelogueTestHelper {
             TraveloguePhotoRepository traveloguePhotoRepository,
             MemberRepository memberRepository,
             TagRepository tagRepository,
-            TravelogueTagRepository travelogueTagRepository
+            TravelogueTagRepository travelogueTagRepository,
+            TravelogueLikeRepository travelogueLikeRepository
     ) {
         this.placeRepository = placeRepository;
         this.travelogueRepository = travelogueRepository;
@@ -60,6 +64,7 @@ public class TravelogueTestHelper {
         this.memberRepository = memberRepository;
         this.tagRepository = tagRepository;
         this.travelogueTagRepository = travelogueTagRepository;
+        this.travelogueLikeRepository = travelogueLikeRepository;
     }
 
     public void initAllTravelogueTestData() {
@@ -120,6 +125,13 @@ public class TravelogueTestHelper {
         persistTraveloguePhoto(place);
 
         tags.forEach(tag -> persisTravelogueTag(travelogue, tag));
+
+        return travelogue;
+    }
+
+    public Travelogue initTravelogueTestDataWithLike(Member liker) {
+        Travelogue travelogue = initTravelogueTestData();
+        travelogueLikeRepository.save(new TravelogueLike(travelogue, liker));
 
         return travelogue;
     }

--- a/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
@@ -69,8 +69,9 @@ public class TravelogueTestHelper {
 
     public void initAllTravelogueTestData() {
         Member author = persistMember();
-        initTravelogueTestData(author);
+        Travelogue travelogue = initTravelogueTestData(author);
         initTravelogueTestDataWithTag(author);
+        persistTravelogueLike(travelogue, author);
     }
 
     public Travelogue initTravelogueTestData() {
@@ -131,7 +132,7 @@ public class TravelogueTestHelper {
 
     public Travelogue initTravelogueTestDataWithLike(Member liker) {
         Travelogue travelogue = initTravelogueTestData();
-        travelogueLikeRepository.save(new TravelogueLike(travelogue, liker));
+        persistTravelogueLike(travelogue, liker);
 
         return travelogue;
     }
@@ -175,6 +176,12 @@ public class TravelogueTestHelper {
         TraveloguePhoto photo = TRAVELOGUE_PHOTO.create(place);
 
         return traveloguePhotoRepository.save(photo);
+    }
+
+    public TravelogueLike persistTravelogueLike(Travelogue travelogue, Member liker) {
+        TravelogueLike like = new TravelogueLike(travelogue, liker);
+
+        return travelogueLikeRepository.save(like);
     }
 
     public Member initKakaoMemberTestData() {

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -136,6 +136,16 @@ class TravelogueFacadeServiceTest {
                 .isEqualTo(TravelogueResponseFixture.getTravelogueResponse());
     }
 
+    @DisplayName("여행기를 ID와 로그인한 사용자를 기준으로 조회한다.")
+    @Test
+    void findTravelogueByIdAndLiker() {
+        Member liker = testHelper.initKakaoMemberTestData();
+        Long travelogueId = testHelper.initTravelogueTestDataWithLike(liker).getId();
+
+        assertThat(service.findTravelogueById(travelogueId, new MemberAuth(liker.getId())))
+                .isEqualTo(TravelogueResponseFixture.getTravelogueResponseWithLike());
+    }
+
     @DisplayName("메인 페이지에 표시할 여행기 목록을 조회한다.")
     @Test
     void findTravelogues() {

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -14,11 +14,13 @@ import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
 import kr.touroot.member.service.MemberService;
+import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.dto.request.TravelogueDayRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
+import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
 import kr.touroot.travelogue.dto.response.TravelogueSimpleResponse;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
 import kr.touroot.travelogue.fixture.TravelogueResponseFixture;
@@ -42,6 +44,7 @@ import org.springframework.data.domain.Sort;
         TravelogueDayService.class,
         TraveloguePlaceService.class,
         TravelogueTagService.class,
+        TravelogueLikeService.class,
         MemberService.class,
         TravelogueTestHelper.class,
         AwsS3Provider.class,
@@ -102,6 +105,26 @@ class TravelogueFacadeServiceTest {
         List<TraveloguePhotoRequest> photos = TravelogueRequestFixture.getTraveloguePhotoRequests();
         List<TraveloguePlaceRequest> places = TravelogueRequestFixture.getTraveloguePlaceRequests(photos);
         return TravelogueRequestFixture.getTravelogueDayRequests(places);
+    }
+
+    @DisplayName("여행기에 좋아요를 할 수 있다.")
+    @Test
+    void likeTravelogue() {
+        Travelogue travelogue = testHelper.initTravelogueTestData();
+        Member liker = testHelper.initKakaoMemberTestData();
+
+        assertThat(service.likeTravelogue(travelogue.getId(), new MemberAuth(liker.getId())))
+                .isEqualTo(new TravelogueLikeResponse(true, 1L));
+    }
+
+    @DisplayName("존재하지 않는 여행기에 좋아요를 하면 예외가 발생한다.")
+    @Test
+    void likeTravelogueWithNotExist() {
+        Member liker = testHelper.initKakaoMemberTestData();
+
+        assertThatThrownBy(() -> service.likeTravelogue(1L, new MemberAuth(liker.getId())))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행기입니다.");
     }
 
     @DisplayName("여행기를 ID를 기준으로 조회한다.")

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -263,4 +263,24 @@ class TravelogueFacadeServiceTest {
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("본인이 작성한 여행기만 수정하거나 삭제할 수 있습니다.");
     }
+
+    @DisplayName("여행기에 좋아요를 취소 할 수 있다.")
+    @Test
+    void unlikeTravelogue() {
+        Member liker = testHelper.initKakaoMemberTestData();
+        Travelogue travelogue = testHelper.initTravelogueTestDataWithLike(liker);
+
+        assertThat(service.unlikeTravelogue(travelogue.getId(), new MemberAuth(liker.getId())))
+                .isEqualTo(new TravelogueLikeResponse(false, 0L));
+    }
+
+    @DisplayName("존재하지 않는 여행기에 좋아요를 취소 하면 예외가 발생한다.")
+    @Test
+    void unlikeTravelogueWithNotExist() {
+        Member liker = testHelper.initKakaoMemberTestData();
+
+        assertThatThrownBy(() -> service.unlikeTravelogue(1L, new MemberAuth(liker.getId())))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행기입니다.");
+    }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
@@ -1,0 +1,58 @@
+package kr.touroot.travelogue.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.touroot.global.ServiceTest;
+import kr.touroot.member.domain.Member;
+import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
+import kr.touroot.travelogue.helper.TravelogueTestHelper;
+import kr.touroot.utils.DatabaseCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@DisplayName("여행기 좋아요 서비스")
+@Import(value = {TravelogueLikeService.class, TravelogueTestHelper.class})
+@ServiceTest
+class TravelogueLikeServiceTest {
+
+    public static final int BASIC_PAGE_SIZE = 5;
+
+    private final TravelogueLikeService travelogueLikeService;
+    private final DatabaseCleaner databaseCleaner;
+    private final TravelogueTestHelper testHelper;
+
+    @Autowired
+    public TravelogueLikeServiceTest(
+            TravelogueLikeService travelogueLikeService,
+            DatabaseCleaner databaseCleaner,
+            TravelogueTestHelper testHelper
+    ) {
+        this.travelogueLikeService = travelogueLikeService;
+        this.databaseCleaner = databaseCleaner;
+        this.testHelper = testHelper;
+    }
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.executeTruncate();
+    }
+
+    @DisplayName("여행기에 좋아요를 할 수 있다.")
+    @Test
+    void likeTravelogue() {
+        // given
+        Travelogue travelogue = testHelper.initTravelogueTestData();
+        Member liker = testHelper.initKakaoMemberTestData();
+
+        // when
+        TravelogueLikeResponse response = travelogueLikeService.likeTravelogue(travelogue, liker);
+
+        // then
+        assertThat(response)
+                .isEqualTo(new TravelogueLikeResponse(true, 1L));
+    }
+}

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
@@ -19,8 +19,6 @@ import org.springframework.context.annotation.Import;
 @ServiceTest
 class TravelogueLikeServiceTest {
 
-    public static final int BASIC_PAGE_SIZE = 5;
-
     private final TravelogueLikeService travelogueLikeService;
     private final DatabaseCleaner databaseCleaner;
     private final TravelogueTestHelper testHelper;
@@ -54,5 +52,20 @@ class TravelogueLikeServiceTest {
         // then
         assertThat(response)
                 .isEqualTo(new TravelogueLikeResponse(true, 1L));
+    }
+
+    @DisplayName("여행기에 좋아요를 취소 할 수 있다.")
+    @Test
+    void unlikeTravelogue() {
+        // given
+        Member liker = testHelper.initKakaoMemberTestData();
+        Travelogue travelogue = testHelper.initTravelogueTestDataWithLike(liker);
+
+        // when
+        TravelogueLikeResponse response = travelogueLikeService.unlikeTravelogue(travelogue, liker);
+
+        // then
+        assertThat(response)
+                .isEqualTo(new TravelogueLikeResponse(false, 0L));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
@@ -50,8 +50,7 @@ class TravelogueLikeServiceTest {
         TravelogueLikeResponse response = travelogueLikeService.findLikeByTravelogue(travelogue);
 
         // then
-        assertThat(response)
-                .isEqualTo(new TravelogueLikeResponse(false, 1L));
+        assertThat(response).isEqualTo(new TravelogueLikeResponse(false, 1L));
     }
 
     @DisplayName("여행기와 좋아요 한 사람을 기반으로 좋아요 정보를 조회할 수 있다.")
@@ -65,8 +64,7 @@ class TravelogueLikeServiceTest {
         TravelogueLikeResponse response = travelogueLikeService.findLikeByTravelogueAndLiker(travelogue, liker);
 
         // then
-        assertThat(response)
-                .isEqualTo(new TravelogueLikeResponse(true, 1L));
+        assertThat(response).isEqualTo(new TravelogueLikeResponse(true, 1L));
     }
 
     @DisplayName("여행기에 좋아요를 할 수 있다.")
@@ -80,8 +78,7 @@ class TravelogueLikeServiceTest {
         TravelogueLikeResponse response = travelogueLikeService.likeTravelogue(travelogue, liker);
 
         // then
-        assertThat(response)
-                .isEqualTo(new TravelogueLikeResponse(true, 1L));
+        assertThat(response).isEqualTo(new TravelogueLikeResponse(true, 1L));
     }
 
     @DisplayName("여행기에 좋아요를 취소 할 수 있다.")
@@ -95,7 +92,6 @@ class TravelogueLikeServiceTest {
         TravelogueLikeResponse response = travelogueLikeService.unlikeTravelogue(travelogue, liker);
 
         // then
-        assertThat(response)
-                .isEqualTo(new TravelogueLikeResponse(false, 0L));
+        assertThat(response).isEqualTo(new TravelogueLikeResponse(false, 0L));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeServiceTest.java
@@ -39,6 +39,36 @@ class TravelogueLikeServiceTest {
         databaseCleaner.executeTruncate();
     }
 
+    @DisplayName("여행기를 기반으로 좋아요 정보를 조회할 수 있다.")
+    @Test
+    void findLikeByTravelogue() {
+        // given
+        Member liker = testHelper.initKakaoMemberTestData();
+        Travelogue travelogue = testHelper.initTravelogueTestDataWithLike(liker);
+
+        // when
+        TravelogueLikeResponse response = travelogueLikeService.findLikeByTravelogue(travelogue);
+
+        // then
+        assertThat(response)
+                .isEqualTo(new TravelogueLikeResponse(false, 1L));
+    }
+
+    @DisplayName("여행기와 좋아요 한 사람을 기반으로 좋아요 정보를 조회할 수 있다.")
+    @Test
+    void findLikeByTravelogueAndLiker() {
+        // given
+        Member liker = testHelper.initKakaoMemberTestData();
+        Travelogue travelogue = testHelper.initTravelogueTestDataWithLike(liker);
+
+        // when
+        TravelogueLikeResponse response = travelogueLikeService.findLikeByTravelogueAndLiker(travelogue, liker);
+
+        // then
+        assertThat(response)
+                .isEqualTo(new TravelogueLikeResponse(true, 1L));
+    }
+
     @DisplayName("여행기에 좋아요를 할 수 있다.")
     @Test
     void likeTravelogue() {


### PR DESCRIPTION
# ✅ 작업 내용

- 좋아요 기능 구현
- 좋아요 취소 기능 구현
- 여행기 조회 시 응답에 좋아요 수, 사용자의 좋아요 여부 추가
- 메인 페이지에서 여행기 조회 시 응답에 좋아요 수 추가

# 🙈 참고 사항
- 좋아요와 좋아요 취소 기능은 반복 요청 시에도 정상적으로 응답합니다. 이는 인스타그램의 게시글 좋아요 기능에서 착안했습니다. 인스타그램에서 게시글 사진을 연속으로 더블 클릭해도 좋아요 상태가 유지되는 것처럼 구현했습니다.
- 프론트엔드 팀과의 논의 결과, 좋아요와 좋아요 취소 요청 시 동시성을 고려하여 응답에 `isLiked`와 `likeCount`를 포함하기로 했습니다. 다만, 좋아요 숫자의 정확성에 대해서는 추가적인 논의가 필요합니다. 이 부분은 전체 회의에서 더 깊이 있게 다루면 좋을 것 같습니다. 자세한 내용은 떼껄룩 문서를 참고해 주세요.
- 여행기 상세 조회 시 로그인/비로그인 사용자에 따라 다른 로직이 실행되어야 합니다. 너무 오래 고민하는 것 같아 일단은 오버로딩으로 구현했지만, 코드가 많이 복잡하다고 느껴집니다. 더 나은 방법을 계속 고민 중이니, 좋은 아이디어가 있으면 공유해 주시기 바랍니다.
