### PR TITLE
[Feature] - 여행 계획 수정 기능 구현

### DIFF
--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -85,6 +86,32 @@ public class TravelPlanController {
     ) {
         PlanResponse data = travelPlanService.readTravelPlan(id, memberAuth);
         return ResponseEntity.ok(data);
+    }
+
+    @Operation(summary = "여행 계획 수정")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "요청 Body에 올바르지 않은 값이 전달되었을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "작성자가 아닌 사용자가 요청했을 때",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<PlanCreateResponse> updateTravelPlan(
+            @PathVariable Long id,
+            @Valid MemberAuth memberAuth,
+            @Valid @RequestBody PlanCreateRequest request
+    ) {
+        return ResponseEntity.ok(travelPlanService.updateTravelPlan(id, memberAuth, request));
     }
 
     @Operation(summary = "여행 계획 삭제")

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -12,7 +12,7 @@ import java.net.URI;
 import java.util.UUID;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.dto.ExceptionResponse;
-import kr.touroot.travelplan.dto.request.PlanCreateRequest;
+import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanResponse;
 import kr.touroot.travelplan.service.TravelPlanService;
@@ -54,7 +54,7 @@ public class TravelPlanController {
     })
     @PostMapping
     public ResponseEntity<PlanCreateResponse> createTravelPlan(
-            @Valid @RequestBody PlanCreateRequest request,
+            @Valid @RequestBody PlanRequest request,
             MemberAuth memberAuth
     ) {
         PlanCreateResponse data = travelPlanService.createTravelPlan(request, memberAuth);
@@ -109,7 +109,7 @@ public class TravelPlanController {
     public ResponseEntity<PlanCreateResponse> updateTravelPlan(
             @PathVariable Long id,
             @Valid MemberAuth memberAuth,
-            @Valid @RequestBody PlanCreateRequest request
+            @Valid @RequestBody PlanRequest request
     ) {
         return ResponseEntity.ok(travelPlanService.updateTravelPlan(id, memberAuth, request));
     }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
@@ -83,6 +83,11 @@ public class TravelPlan extends BaseEntity {
         }
     }
 
+    public void update(String title, LocalDate startDate) {
+        this.title = title;
+        this.startDate = startDate;
+    }
+
     public boolean isStartDateBefore(LocalDate date) {
         return startDate.isBefore(date);
     }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanDayRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanDayRequest.java
@@ -8,12 +8,12 @@ import java.util.List;
 import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.domain.TravelPlanDay;
 
-public record PlanDayCreateRequest(
+public record PlanDayRequest(
         @Schema(description = "여행 장소 정보")
         @Valid
         @Size(min = 1, message = "여행 장소는 한 개 이상이어야 합니다.")
         @NotNull(message = "여행 장소 정보는 비어있을 수 없습니다.")
-        List<PlanPlaceCreateRequest> places
+        List<PlanPlaceRequest> places
 ) {
 
     public TravelPlanDay toPlanDay(int order, TravelPlan plan) {

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceRequest.java
@@ -11,12 +11,12 @@ import kr.touroot.travelplan.domain.TravelPlanPlace;
 import lombok.Builder;
 
 @Builder
-public record PlanPlaceCreateRequest(
+public record PlanPlaceRequest(
         @Schema(description = "여행 장소 이름", example = "잠실한강공원")
         @NotBlank(message = "장소명은 비어있을 수 없습니다.") String placeName,
         @Valid
         @NotNull(message = "위치는 비어있을 수 없습니다.")
-        PlanPositionCreateRequest position,
+        PlanPositionRequest position,
         @Valid
         @NotNull(message = "TODO 리스트는 필수 입니다.")
         List<PlanPlaceTodoRequest> todos

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceTodoRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceTodoRequest.java
@@ -2,6 +2,7 @@ package kr.touroot.travelplan.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.touroot.travelplan.domain.TravelPlaceTodo;
 import kr.touroot.travelplan.domain.TravelPlanPlace;
@@ -10,10 +11,13 @@ public record PlanPlaceTodoRequest(
         @Schema(description = "여행 장소에서 진행할 TODO", example = "함덕 해수욕장 산책")
         @NotBlank(message = "TODO 내용은 비어 있을 수 없습니다")
         @Size(min = 1, max = 20, message = "TODO 내용은 1자에서 20자 사이의 길이를 가져야 합니다")
-        String content
+        String content,
+        @Schema(description = "TODO의 체크 여부", example = "true")
+        @NotNull(message = "TODO의 체크 여부는 비어 있을 수 없습니다.")
+        Boolean isChecked
 ) {
 
     public TravelPlaceTodo toUncheckedPlaceTodo(TravelPlanPlace travelPlanPlace, Integer order) {
-        return new TravelPlaceTodo(travelPlanPlace, content, order, false);
+        return new TravelPlaceTodo(travelPlanPlace, content, order, isChecked);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceTodoRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceTodoRequest.java
@@ -17,7 +17,7 @@ public record PlanPlaceTodoRequest(
         Boolean isChecked
 ) {
 
-    public TravelPlaceTodo toUncheckedPlaceTodo(TravelPlanPlace travelPlanPlace, Integer order) {
+    public TravelPlaceTodo toPlaceTodo(TravelPlanPlace travelPlanPlace, Integer order) {
         return new TravelPlaceTodo(travelPlanPlace, content, order, isChecked);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPositionRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPositionRequest.java
@@ -3,7 +3,7 @@ package kr.touroot.travelplan.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record PlanPositionCreateRequest(
+public record PlanPositionRequest(
         @Schema(description = "여행 장소 위도", example = "37.5175896")
         @NotNull(message = "위도는 비어있을 수 없습니다.")
         String lat,

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanRequest.java
@@ -13,7 +13,7 @@ import kr.touroot.travelplan.domain.TravelPlan;
 import lombok.Builder;
 
 @Builder
-public record PlanCreateRequest(
+public record PlanRequest(
         @Schema(description = "여행 계획 제목", example = "신나는 잠실 한강 여행")
         @NotBlank(message = "여행 계획 제목은 비어있을 수 없습니다.")
         String title,
@@ -24,7 +24,7 @@ public record PlanCreateRequest(
         @Valid
         @Size(min = 1, message = "여행 날짜는 하루 이상 있어야 합니다.")
         @NotNull(message = "여행 날짜 정보는 비어있을 수 없습니다.")
-        List<PlanDayCreateRequest> days
+        List<PlanDayRequest> days
 ) {
 
     public TravelPlan toTravelPlan(Member author, UUID shareKey) {

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -89,7 +89,7 @@ public class TravelPlanService {
     private void createPlaceTodo(List<PlanPlaceTodoRequest> request, TravelPlanPlace travelPlanPlace) {
         for (int order = 0; order < request.size(); order++) {
             PlanPlaceTodoRequest todoRequest = request.get(order);
-정            TravelPlaceTodo travelPlaceTodo = todoRequest.toPlaceTodo(travelPlanPlace, order);
+            TravelPlaceTodo travelPlaceTodo = todoRequest.toPlaceTodo(travelPlanPlace, order);
             placeTodoRepository.save(travelPlaceTodo);
         }
     }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -89,7 +89,7 @@ public class TravelPlanService {
     private void createPlaceTodo(List<PlanPlaceTodoRequest> request, TravelPlanPlace travelPlanPlace) {
         for (int order = 0; order < request.size(); order++) {
             PlanPlaceTodoRequest todoRequest = request.get(order);
-            TravelPlaceTodo travelPlaceTodo = todoRequest.toUncheckedPlaceTodo(travelPlanPlace, order);
+정            TravelPlaceTodo travelPlaceTodo = todoRequest.toPlaceTodo(travelPlanPlace, order);
             placeTodoRepository.save(travelPlaceTodo);
         }
     }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -15,10 +15,10 @@ import kr.touroot.travelplan.domain.TravelPlaceTodo;
 import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.domain.TravelPlanDay;
 import kr.touroot.travelplan.domain.TravelPlanPlace;
-import kr.touroot.travelplan.dto.request.PlanCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanDayCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanPlaceCreateRequest;
+import kr.touroot.travelplan.dto.request.PlanDayRequest;
+import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
 import kr.touroot.travelplan.dto.request.PlanPlaceTodoRequest;
+import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanDayResponse;
 import kr.touroot.travelplan.dto.response.PlanPlaceResponse;
@@ -46,7 +46,7 @@ public class TravelPlanService {
     private final PlaceTodoRepository placeTodoRepository;
 
     @Transactional
-    public PlanCreateResponse createTravelPlan(PlanCreateRequest request, MemberAuth memberAuth) {
+    public PlanCreateResponse createTravelPlan(PlanRequest request, MemberAuth memberAuth) {
         Member author = getMemberByMemberAuth(memberAuth);
         TravelPlan travelPlan = request.toTravelPlan(author, UUID.randomUUID());
         validateCreateTravelPlan(travelPlan);
@@ -68,17 +68,17 @@ public class TravelPlanService {
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 사용자입니다."));
     }
 
-    private void createPlanDay(List<PlanDayCreateRequest> request, TravelPlan savedTravelPlan) {
+    private void createPlanDay(List<PlanDayRequest> request, TravelPlan savedTravelPlan) {
         for (int order = 0; order < request.size(); order++) {
-            PlanDayCreateRequest dayRequest = request.get(order);
+            PlanDayRequest dayRequest = request.get(order);
             TravelPlanDay travelPlanDay = travelPlanDayRepository.save(dayRequest.toPlanDay(order, savedTravelPlan));
             createPlanPlace(dayRequest.places(), travelPlanDay);
         }
     }
 
-    private void createPlanPlace(List<PlanPlaceCreateRequest> request, TravelPlanDay travelPlanDay) {
+    private void createPlanPlace(List<PlanPlaceRequest> request, TravelPlanDay travelPlanDay) {
         for (int order = 0; order < request.size(); order++) {
-            PlanPlaceCreateRequest planRequest = request.get(order);
+            PlanPlaceRequest planRequest = request.get(order);
             Place place = getPlace(planRequest);
             TravelPlanPlace planPlace = planRequest.toPlanPlace(order, travelPlanDay, place);
             TravelPlanPlace travelPlanPlace = travelPlanPlaceRepository.save(planPlace);
@@ -94,7 +94,7 @@ public class TravelPlanService {
         }
     }
 
-    private Place getPlace(PlanPlaceCreateRequest planRequest) {
+    private Place getPlace(PlanPlaceRequest planRequest) {
         return placeRepository.findByNameAndLatitudeAndLongitude(
                 planRequest.placeName(),
                 planRequest.position().lat(),
@@ -174,7 +174,7 @@ public class TravelPlanService {
     }
 
     @Transactional
-    public PlanCreateResponse updateTravelPlan(Long planId, MemberAuth memberAuth, PlanCreateRequest request) {
+    public PlanCreateResponse updateTravelPlan(Long planId, MemberAuth memberAuth, PlanRequest request) {
         TravelPlan travelPlan = getTravelPlanById(planId);
         Member author = getMemberByMemberAuth(memberAuth);
         validateUpdateByAuthor(travelPlan, author);
@@ -196,7 +196,7 @@ public class TravelPlanService {
         travelPlanDayRepository.deleteByPlan(travelPlan);
     }
 
-    private void updateTravelPlanContents(PlanCreateRequest request, TravelPlan travelPlan) {
+    private void updateTravelPlanContents(PlanRequest request, TravelPlan travelPlan) {
         travelPlan.update(request.title(), request.startDate());
         travelPlanRepository.save(travelPlan);
         createPlanDay(request.days(), travelPlan);

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -13,10 +13,10 @@ import kr.touroot.authentication.infrastructure.JwtTokenProvider;
 import kr.touroot.global.AcceptanceTest;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelplan.domain.TravelPlan;
-import kr.touroot.travelplan.dto.request.PlanCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanDayCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanPlaceCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanPositionCreateRequest;
+import kr.touroot.travelplan.dto.request.PlanDayRequest;
+import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
+import kr.touroot.travelplan.dto.request.PlanPositionRequest;
+import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.helper.TravelPlanTestHelper;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,18 +65,18 @@ class TravelPlanControllerTest {
     @Test
     void createTravelPlan() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
 
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then
@@ -95,17 +95,17 @@ class TravelPlanControllerTest {
     @Test
     void createTravelPlanWithInvalidStartDate() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MIN)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then
@@ -251,18 +251,18 @@ class TravelPlanControllerTest {
     void updateTravelPlan() {
         // given
         TravelPlan travelPlan = testHelper.initTravelPlanTestData(member);
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
 
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then
@@ -280,18 +280,18 @@ class TravelPlanControllerTest {
     @Test
     void updateTravelPlanWithNonExist() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
 
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then
@@ -312,18 +312,18 @@ class TravelPlanControllerTest {
         long id = testHelper.initTravelPlanTestData(member).getId();
         Member notAuthor = testHelper.initMemberTestData();
         String notAuthorAccessToken = jwtTokenProvider.createToken(notAuthor.getId()).accessToken();
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
 
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -246,6 +246,97 @@ class TravelPlanControllerTest {
                 .body("message", is("존재하지 않는 여행 계획입니다."));
     }
 
+    @DisplayName("여행기를 수정한다.")
+    @Test
+    void updateTravelPlan() {
+        // given
+        TravelPlan travelPlan = testHelper.initTravelPlanTestData(member);
+        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
+        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+
+        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
+        PlanCreateRequest request = PlanCreateRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayCreateRequest))
+                .build();
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .body(request)
+                .when().put("/api/v1/travel-plans/" + travelPlan.getId())
+                .then().log().all()
+                .statusCode(200)
+                .body("id", is(1));
+    }
+
+    @DisplayName("존재하지 않는 여행 계획 수정시 400를 응답한다.")
+    @Test
+    void updateTravelPlanWithNonExist() {
+        // given
+        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
+        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+
+        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
+        PlanCreateRequest request = PlanCreateRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayCreateRequest))
+                .build();
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .body(request)
+                .when().put("/api/v1/travel-plans/" + 1)
+                .then().log().all()
+                .statusCode(400)
+                .body("message", is("존재하지 않는 여행 계획입니다."));
+    }
+
+    @DisplayName("작성자가 아닌 사용자가 여행 계획 수정시 403을 응답한다.")
+    @Test
+    void updateTravelPlanWithNotAuthor() {
+        // given
+        long id = testHelper.initTravelPlanTestData(member).getId();
+        Member notAuthor = testHelper.initMemberTestData();
+        String notAuthorAccessToken = jwtTokenProvider.createToken(notAuthor.getId()).accessToken();
+        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
+        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+
+        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
+        PlanCreateRequest request = PlanCreateRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayCreateRequest))
+                .build();
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + notAuthorAccessToken)
+                .body(request)
+                .when().put("/api/v1/travel-plans/" + id)
+                .then().log().all()
+                .statusCode(403)
+                .body("message", is("여행 계획 수정은 작성자만 가능합니다."));
+    }
+
     @DisplayName("여행계획을 삭제한다.")
     @Test
     void deleteTravelPlan() {

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -184,6 +184,80 @@ class TravelPlanServiceTest {
         assertThat(actual).isEqualTo(1);
     }
 
+    @DisplayName("여행 계획 서비스는 새로운 정보로 여행 계획을 수정한다.")
+    @Test
+    void updateTravelPlan() {
+        // given
+        TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
+        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
+        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
+        PlanCreateRequest request = PlanCreateRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayCreateRequest))
+                .build();
+
+        // when
+        PlanCreateResponse updatedTravelPlan = travelPlanService.updateTravelPlan(travelPlan.getId(), memberAuth,
+                request);
+
+        // then
+        assertThat(updatedTravelPlan.id()).isEqualTo(1L);
+    }
+
+    @DisplayName("여행 계획 서비스는 존재하지 않는 여행 계획 수정 시 예외를 반환한다.")
+    @Test
+    void updateTravelPlanWitNonExist() {
+        // given
+        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
+        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
+        PlanCreateRequest request = PlanCreateRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayCreateRequest))
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> travelPlanService.updateTravelPlan(1L, memberAuth, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 여행 계획입니다.");
+    }
+
+    @DisplayName("여행 계획 서비스는 작성자가 아닌 사용자가 수정 시 예외를 반환한다.")
+    @Test
+    void updateTravelPlanWithNotAuthor() {
+        // given
+        Long id = testHelper.initTravelPlanTestData(author).getId();
+        MemberAuth notAuthor = new MemberAuth(testHelper.initMemberTestData().getId());
+        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
+        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
+        PlanCreateRequest request = PlanCreateRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayCreateRequest))
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> travelPlanService.updateTravelPlan(id, notAuthor, request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("여행 계획 수정은 작성자만 가능합니다.");
+    }
+
     @DisplayName("여행계획을 ID 기준으로 삭제할 수 있다.")
     @Test
     void deleteTravelPlanById() {

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -14,10 +14,10 @@ import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelplan.domain.TravelPlan;
-import kr.touroot.travelplan.dto.request.PlanCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanDayCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanPlaceCreateRequest;
-import kr.touroot.travelplan.dto.request.PlanPositionCreateRequest;
+import kr.touroot.travelplan.dto.request.PlanDayRequest;
+import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
+import kr.touroot.travelplan.dto.request.PlanPositionRequest;
+import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanResponse;
 import kr.touroot.travelplan.helper.TravelPlanTestHelper;
@@ -67,17 +67,17 @@ class TravelPlanServiceTest {
     @Test
     void createTravelPlan() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when
@@ -91,17 +91,17 @@ class TravelPlanServiceTest {
     @Test
     void createTravelPlanWithInvalidStartDate() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .position(locationRequest)
                 .todos(Collections.EMPTY_LIST)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MIN)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then=
@@ -114,17 +114,17 @@ class TravelPlanServiceTest {
     @Test
     void createTravelPlanStartsAtToday() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.now())
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then=
@@ -189,17 +189,17 @@ class TravelPlanServiceTest {
     void updateTravelPlan() {
         // given
         TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when
@@ -214,17 +214,17 @@ class TravelPlanServiceTest {
     @Test
     void updateTravelPlanWitNonExist() {
         // given
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then
@@ -239,17 +239,17 @@ class TravelPlanServiceTest {
         // given
         Long id = testHelper.initTravelPlanTestData(author).getId();
         MemberAuth notAuthor = new MemberAuth(testHelper.initMemberTestData().getId());
-        PlanPositionCreateRequest locationRequest = new PlanPositionCreateRequest("37.5175896", "127.0867236");
-        PlanPlaceCreateRequest planPlaceCreateRequest = PlanPlaceCreateRequest.builder()
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
                 .placeName("잠실한강공원")
                 .todos(Collections.EMPTY_LIST)
                 .position(locationRequest)
                 .build();
-        PlanDayCreateRequest planDayCreateRequest = new PlanDayCreateRequest(List.of(planPlaceCreateRequest));
-        PlanCreateRequest request = PlanCreateRequest.builder()
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
                 .startDate(LocalDate.MAX)
-                .days(List.of(planDayCreateRequest))
+                .days(List.of(planDayRequest))
                 .build();
 
         // when & then


### PR DESCRIPTION
# ✅ 작업 내용

-  PUT Method 매핑
-  엔티티 수정 기능 구현

# 🙈 참고 사항
- 이미 여행을 간 상태에서 수정을 할 수 있다고 생각해 지난 날짜 검증은 하지 않았습니다.
- 일단 갖고 있는 하위 엔티티들을 전부 삭제 후 다시 생성하는 식으로 구현했기 때문에 Todo의 checked를 알아야 합니다. 따라서 TODO 요청 객체에서 해당 boolean 값도 받도록 수정했습니다.
- 여행 계획 관련 createRequest 객체들을 재사용하는 편이 깔끔할 것 같아 create를 빼고 사용하도록 수정했습니다.