### PR TITLE
[Feature] - Spring boot Prod 프로필 분리

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:17-oracle
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "/app.jar"]

--- a/backend/src/main/java/kr/touroot/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/kr/touroot/global/config/SwaggerConfig.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 
+@Profile("local|dev")
 @Configuration
 public class SwaggerConfig {
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -116,8 +116,8 @@ spring:
 server:
   ssl:
     key-store-type: PKCS12
-    key-store-password: ENC(faQYah2QoIaNVRZD9J6/junPRWkc5gaiAs+mEbxDk+I=)
-    key-store: ENC(7VQCNdI7mXATwc4AiymZoyf3mz9SiskXpLnenpMSFBI=)
+    key-store-password: ENC(WyJqMojCOPDe932QhOR52Ll0EhthbUe5ycHs0WWifQg=)
+    key-store: ENC(DtVtAx+kVnU581+bjT7A3vCLbJ8fe3JqUritO+0WJ/Q=)
 
 security:
   jwt:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,10 +3,12 @@ oauth:
     user-information-request-uri: https://kapi.kakao.com/v2/user/me
     access-token-request-uri: https://kauth.kakao.com/oauth/token
     rest-api-key: ENC(i6J7NWUsDpXVbJrbSUcNFI3h0oc6v8PxuHShU9UA7EVuUNLtQN/ANII+8j5HjhGO)
+
 jasypt:
   encryptor:
     algorithm: PBEWithMD5AndDES
     iv-generator-classname: org.jasypt.iv.NoIvGenerator
+
 cloud:
   aws:
     s3:
@@ -125,3 +127,7 @@ security:
     refresh:
       secret-key: ENC(KzrDzCSz4dIMMP6Vsyd9cYvOvGXMbetrCDAX0/IpHfVW7kdsbV2+ZlGcBz+RCS2whMPuoCxdhyE=)
       expire-length: 1209600000 # 14 days
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,14 +17,6 @@ cloud:
       image-storage-path: images/
 ---
 # local profile
-security:
-  jwt:
-    token:
-      secret-key: ENC(SNwFG2NQDZkmIK3nNoZFdwQ0ZxKuoe+qcw10ljdW941YEx/Qky9PEEl+wvAN9S1KR26D3a83SnU=)
-      expire-length: 1800000 # 30 min
-    refresh:
-      secret-key: ENC(tneEW6IKq9XuDoxAoKvBEVER4xjLHCycWXMa+Rnzb700ndTnrkJ2mOtBPP5hEIJLRNgj5MLIhYs=)
-      expire-length: 1209600000 # 14 days
 spring:
   config:
     activate:
@@ -40,34 +32,29 @@ spring:
     show-sql: false
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: true
----
-# dev profile
+
 security:
   jwt:
     token:
-      secret-key: ENC(L36WWjoZtP2nHHkqxDGlYLsMHMp+EBL2Fnl+X2de2KHk+PIfViyVM7rCYcbcFpo7yB4MaP++atU=)
+      secret-key: ENC(SNwFG2NQDZkmIK3nNoZFdwQ0ZxKuoe+qcw10ljdW941YEx/Qky9PEEl+wvAN9S1KR26D3a83SnU=)
       expire-length: 1800000 # 30 min
     refresh:
-      secret-key: ENC(cDstTL4/ajLm3NohJwMR9vEBsIZeD9Vt+jE1obdwL8Q6gMnWvY3N+bmNsC9N0csaa6AaYIZLbFM=)
+      secret-key: ENC(tneEW6IKq9XuDoxAoKvBEVER4xjLHCycWXMa+Rnzb700ndTnrkJ2mOtBPP5hEIJLRNgj5MLIhYs=)
       expire-length: 1209600000 # 14 days
-server:
-  ssl:
-    key-store-type: PKCS12
-    key-store-password: ENC(faQYah2QoIaNVRZD9J6/junPRWkc5gaiAs+mEbxDk+I=)
-    key-store: ENC(7VQCNdI7mXATwc4AiymZoyf3mz9SiskXpLnenpMSFBI=)
+---
+# dev profile
 spring:
+  config:
+    activate:
+      on-profile: dev
   servlet:
     multipart:
       max-file-size: 25MB
       max-request-size: 250MB
-  config:
-    activate:
-      on-profile: dev
   h2:
     console:
       enabled: false
@@ -80,7 +67,61 @@ spring:
     show-sql: false
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: none
+
+server:
+  ssl:
+    key-store-type: PKCS12
+    key-store-password: ENC(faQYah2QoIaNVRZD9J6/junPRWkc5gaiAs+mEbxDk+I=)
+    key-store: ENC(7VQCNdI7mXATwc4AiymZoyf3mz9SiskXpLnenpMSFBI=)
+
+security:
+  jwt:
+    token:
+      secret-key: ENC(L36WWjoZtP2nHHkqxDGlYLsMHMp+EBL2Fnl+X2de2KHk+PIfViyVM7rCYcbcFpo7yB4MaP++atU=)
+      expire-length: 1800000 # 30 min
+    refresh:
+      secret-key: ENC(cDstTL4/ajLm3NohJwMR9vEBsIZeD9Vt+jE1obdwL8Q6gMnWvY3N+bmNsC9N0csaa6AaYIZLbFM=)
+      expire-length: 1209600000 # 14 days
+---
+# prod profile
+spring:
+  config:
+    activate:
+      on-profile: prod
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 250MB
+  h2:
+    console:
+      enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ENC(BLlw5HyZCuuLnw9MN5Ez395f+9INR7KoyWKUArAGc5QuMNJw07P06/1HLSZZ6y8M)
+    username: ENC(s5TCLskHnyopzJBsWU9Akg==)
+    password: ENC(MlRZxamsKXaRANlE3dX9T3vrdJhtsoE0r6LvSaKZoSU=)
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: none
+
+server:
+  ssl:
+    key-store-type: PKCS12
+    key-store-password: ENC(faQYah2QoIaNVRZD9J6/junPRWkc5gaiAs+mEbxDk+I=)
+    key-store: ENC(7VQCNdI7mXATwc4AiymZoyf3mz9SiskXpLnenpMSFBI=)
+
+security:
+  jwt:
+    token:
+      secret-key: ENC(1oFbXL7gi5RoZ3477IE75WnKK6t/Mq18IRzKB4TjRI/kb5ViYqbkBesMhPzjakFnAeqwiIWg0cQ=)
+      expire-length: 1800000 # 30 min
+    refresh:
+      secret-key: ENC(KzrDzCSz4dIMMP6Vsyd9cYvOvGXMbetrCDAX0/IpHfVW7kdsbV2+ZlGcBz+RCS2whMPuoCxdhyE=)
+      expire-length: 1209600000 # 14 days

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -84,4 +84,13 @@
             <appender-ref ref="FILE-ERROR"/>
         </root>
     </springProfile>
+
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-WARN"/>
+            <appender-ref ref="FILE-ERROR"/>
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
# ✅ 작업 내용

- Spring boot Prod 분리
- prod 프로필에서 swagger 비활성화
- Dockerfile에서 프로필 지정 부분 제거 및 docker-compose.yml 수정

# 🙈 참고 사항

- Dockerfile에서 profile 지정하는 부분 변경하고 각 인스턴스의 docker-compose.yml에 프로필 지정 환경 변수 추가했습니다.
- @hangillee prod용 CI/CD에서 keystore 생성 시 `PROD_KEY_STORE` secret 사용해서 생성해야 올바른 인증서로 생성됩니다.