### PR TITLE
[Fix] - 삭제 기능 쿼리 문제 해결

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePhotoRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TraveloguePhotoRepository.java
@@ -13,6 +13,6 @@ public interface TraveloguePhotoRepository extends JpaRepository<TraveloguePhoto
     List<TraveloguePhoto> findByTraveloguePlace(TraveloguePlace traveloguePlace);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE TraveloguePhoto tp SET tp.deletedAt = NOW() WHERE tp.traveloguePlace.travelogueDay.travelogue = :travelogue")
+    @Query("UPDATE TraveloguePhoto to SET to.deletedAt = NOW() WHERE to.traveloguePlace.travelogueDay.travelogue = :travelogue")
     void deleteAllByTraveloguePlaceTravelogueDayTravelogue(Travelogue travelogue);
 }


### PR DESCRIPTION
# ✅ 작업 내용

- `TraveloguePlace`와 `TraveloguePhoto` 삭제 쿼리의 테이블 alias 중복 제거
