### PR TITLE
[Fix] - 여행기 수정 시 이미 업로드 된 사진을 처리하지 못하는 오류

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TraveloguePhotoService {
 
+    private static final String TEMPORARY_IMAGE_PATH = "https://dev.touroot.kr/temporary/";
+
     private final TraveloguePhotoRepository traveloguePhotoRepository;
     private final AwsS3Provider s3Provider;
 
@@ -38,7 +40,7 @@ public class TraveloguePhotoService {
     }
 
     private boolean isNotInPermanentStorage(String imageUrl) {
-        if (imageUrl.startsWith("https://dev.touroot.kr/temporary/")) {
+        if (imageUrl.startsWith(TEMPORARY_IMAGE_PATH)) {
             return true;
         }
         return false;

--- a/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TraveloguePhotoService.java
@@ -26,12 +26,22 @@ public class TraveloguePhotoService {
 
         for (int i = 0; i < requests.size(); i++) {
             TraveloguePhotoRequest request = requests.get(i);
-            String url = s3Provider.copyImageToPermanentStorage(request.url());
+            String url = request.url();
+            if (isNotInPermanentStorage(request.url())) {
+                url = s3Provider.copyImageToPermanentStorage(request.url());
+            }
             TraveloguePhoto photo = new TraveloguePhoto(i, url, place);
             photos.add(traveloguePhotoRepository.save(photo));
         }
 
         return photos;
+    }
+
+    private boolean isNotInPermanentStorage(String imageUrl) {
+        if (imageUrl.startsWith("https://dev.touroot.kr/temporary/")) {
+            return true;
+        }
+        return false;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# ✅ 작업 내용
- 이미지 경로에 따라 영구 저장소 이동 여부를 분기 한다.

# 🙈 참고 사항
