### PR TITLE
[Fix] - 여행 계획 수정, 마이페이지, 검색 페이지 에러 핸들링

### DIFF
--- a/frontend/src/components/pages/my/MyPage.tsx
+++ b/frontend/src/components/pages/my/MyPage.tsx
@@ -13,7 +13,7 @@ import MyTravelPlans from "./MyTravelPlans/MyTravelPlans";
 import MyTravelogues from "./MyTravelogues/MyTravelogues";
 
 const MyPage = () => {
-  const { data, isLoading } = useUserProfile();
+  const { data, isLoading, error } = useUserProfile();
   const [isModifying, setIsModifying] = useState(false);
   const [nickname, setNickname] = useState(data?.nickname ?? "");
 
@@ -33,6 +33,8 @@ const MyPage = () => {
   const handleStartNicknameEdit = () => {
     setIsModifying(true);
   };
+
+  if (error) alert(error.message);
 
   const handleSubmitNicknameChange = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/src/components/pages/my/MyPage.tsx
+++ b/frontend/src/components/pages/my/MyPage.tsx
@@ -95,10 +95,15 @@ const MyPage = () => {
         storageKey={STORAGE_KEYS_MAP.myPageSelectedTabIndex}
         labels={["내 여행 계획", "내 여행기"]}
         tabContent={(selectedIndex) => (
-          <>{selectedIndex === 0 ? <MyTravelPlans /> : <MyTravelogues />}</>
+          <>
+            {selectedIndex === 0 ? (
+              data ? (
+                <MyTravelPlans userData={data} />
+              ) : null
             ) : data ? (
               <MyTravelogues userData={data} />
             ) : null}
+          </>
         )}
         css={S.ListStyle}
       />

--- a/frontend/src/components/pages/my/MyPage.tsx
+++ b/frontend/src/components/pages/my/MyPage.tsx
@@ -94,6 +94,9 @@ const MyPage = () => {
         labels={["내 여행 계획", "내 여행기"]}
         tabContent={(selectedIndex) => (
           <>{selectedIndex === 0 ? <MyTravelPlans /> : <MyTravelogues />}</>
+            ) : data ? (
+              <MyTravelogues userData={data} />
+            ) : null}
         )}
         css={S.ListStyle}
       />

--- a/frontend/src/components/pages/my/MyTravelPlans/MyTravelPlans.tsx
+++ b/frontend/src/components/pages/my/MyTravelPlans/MyTravelPlans.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { css } from "@emotion/react";
@@ -24,7 +25,7 @@ const MyTravelPlans = () => {
   const { onTransformTravelDetail } = useTravelTransformDetailContext();
   const navigate = useNavigate();
 
-  const { myTravelPlans, status, fetchNextPage } = useInfiniteMyTravelPlans();
+  const { myTravelPlans, status, fetchNextPage, isPaused, error } =
   const { lastElementRef } = useIntersectionObserver(fetchNextPage);
 
   const handleClickAddButton = () => {
@@ -35,7 +36,13 @@ const MyTravelPlans = () => {
     navigate(ROUTE_PATHS_MAP.travelPlan(Number(id)));
   };
 
+  useEffect(() => {
+    if (isPaused) alert(ERROR_MESSAGE_MAP.network);
+  }, [isPaused]);
+
   if (status === "pending") return <MyPageTabContentSkeleton />;
+
+  if (error) alert(error.message);
 
   return (
     <>

--- a/frontend/src/components/pages/my/MyTravelPlans/MyTravelPlans.tsx
+++ b/frontend/src/components/pages/my/MyTravelPlans/MyTravelPlans.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 
 import { css } from "@emotion/react";
 
+import type { UserResponse } from "@type/domain/user";
+
 import { useTravelTransformDetailContext } from "@contexts/TravelTransformDetailProvider";
 
 import useInfiniteMyTravelPlans from "@queries/useInfiniteMyTravelPlans";
@@ -22,10 +24,16 @@ import TabContent from "../MyPageTabContent/MyPageTabContent";
 import * as S from "./MyTravelPlans.styled";
 
 const MyTravelPlans = () => {
+interface MyTravelPlansProps {
+  userData: UserResponse;
+}
+
+const MyTravelPlans = ({ userData }: MyTravelPlansProps) => {
   const { onTransformTravelDetail } = useTravelTransformDetailContext();
   const navigate = useNavigate();
 
   const { myTravelPlans, status, fetchNextPage, isPaused, error } =
+    useInfiniteMyTravelPlans(userData);
   const { lastElementRef } = useIntersectionObserver(fetchNextPage);
 
   const handleClickAddButton = () => {

--- a/frontend/src/components/pages/my/MyTravelPlans/MyTravelPlans.tsx
+++ b/frontend/src/components/pages/my/MyTravelPlans/MyTravelPlans.tsx
@@ -14,6 +14,7 @@ import MyPageTabContentSkeleton from "@components/pages/my/MyPageTabContentSkele
 
 import useIntersectionObserver from "@hooks/useIntersectionObserver";
 
+import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
 import { ROUTE_PATHS_MAP } from "@constants/route";
 
 import addDaysToDateString from "@utils/addDaysToDateString";
@@ -23,7 +24,6 @@ import theme from "@styles/theme";
 import TabContent from "../MyPageTabContent/MyPageTabContent";
 import * as S from "./MyTravelPlans.styled";
 
-const MyTravelPlans = () => {
 interface MyTravelPlansProps {
   userData: UserResponse;
 }

--- a/frontend/src/components/pages/my/MyTravelogues/MyTravelogues.tsx
+++ b/frontend/src/components/pages/my/MyTravelogues/MyTravelogues.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { css } from "@emotion/react";
@@ -17,7 +18,7 @@ import TabContent from "../MyPageTabContent/MyPageTabContent";
 import * as S from "./MyTravelogues.styled";
 
 const MyTravelogues = () => {
-  const { myTravelogues, fetchNextPage, status } = useInfiniteMyTravelogues();
+  const { myTravelogues, fetchNextPage, status, isPaused, error } =
   const { lastElementRef } = useIntersectionObserver(fetchNextPage);
 
   const navigate = useNavigate();
@@ -29,6 +30,10 @@ const MyTravelogues = () => {
   const handleClickTravelogue = (id: string) => {
     navigate(ROUTE_PATHS_MAP.travelogue(Number(id)));
   };
+
+  useEffect(() => {
+    if (isPaused) alert(ERROR_MESSAGE_MAP.network);
+  }, [isPaused]);
 
   if (status === "pending") return <MyPageTabContentSkeleton />;
 

--- a/frontend/src/components/pages/my/MyTravelogues/MyTravelogues.tsx
+++ b/frontend/src/components/pages/my/MyTravelogues/MyTravelogues.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 
 import { css } from "@emotion/react";
 
+import type { UserResponse } from "@type/domain/user";
+
 import useInfiniteMyTravelogues from "@queries/useInfiniteMyTravelogues";
 
 import { AvatarCircle, Text } from "@components/common";
@@ -10,6 +12,7 @@ import MyPageTabContentSkeleton from "@components/pages/my/MyPageTabContentSkele
 
 import useIntersectionObserver from "@hooks/useIntersectionObserver";
 
+import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
 import { ROUTE_PATHS_MAP } from "@constants/route";
 
 import theme from "@styles/theme";
@@ -17,8 +20,13 @@ import theme from "@styles/theme";
 import TabContent from "../MyPageTabContent/MyPageTabContent";
 import * as S from "./MyTravelogues.styled";
 
-const MyTravelogues = () => {
+interface MyTraveloguesProps {
+  userData: UserResponse;
+}
+
+const MyTravelogues = ({ userData }: MyTraveloguesProps) => {
   const { myTravelogues, fetchNextPage, status, isPaused, error } =
+    useInfiniteMyTravelogues(userData);
   const { lastElementRef } = useIntersectionObserver(fetchNextPage);
 
   const navigate = useNavigate();
@@ -36,6 +44,8 @@ const MyTravelogues = () => {
   }, [isPaused]);
 
   if (status === "pending") return <MyPageTabContentSkeleton />;
+
+  if (error) alert(error.message);
 
   return (
     <>

--- a/frontend/src/components/pages/search/SearchPage.tsx
+++ b/frontend/src/components/pages/search/SearchPage.tsx
@@ -9,6 +9,8 @@ import TravelogueCard from "@components/pages/main/TravelogueCard/TravelogueCard
 
 import useIntersectionObserver from "@hooks/useIntersectionObserver";
 
+import { ERROR_MESSAGE_MAP } from "@constants/errorMessage";
+
 import { extractLastPath } from "@utils/extractId";
 
 import TravelogueCardSkeleton from "../main/TravelogueCard/skeleton/TravelogueCardSkeleton";
@@ -22,7 +24,8 @@ const SearchPage = () => {
     location.pathname.split("/").length > 2 ? extractLastPath(location.pathname) : "";
   const keyword = encodedKeyword ? decodeURIComponent(encodedKeyword) : "";
 
-  const { travelogues, status, fetchNextPage } = useInfiniteSearchTravelogues(keyword);
+  const { travelogues, status, fetchNextPage, isPaused, error } =
+    useInfiniteSearchTravelogues(keyword);
 
   const { lastElementRef } = useIntersectionObserver(fetchNextPage);
 
@@ -49,6 +52,14 @@ const SearchPage = () => {
       </S.Layout>
     );
   }
+
+  if (status === "error") {
+    error && alert(error.message);
+
+    return <SearchFallback title="휑" text="검색 결과가 없어요." />;
+  }
+
+  if (isPaused) alert(ERROR_MESSAGE_MAP.network);
 
   return (
     <S.Layout>

--- a/frontend/src/components/pages/travelPlanEdit/TravelPlanEditPage.tsx
+++ b/frontend/src/components/pages/travelPlanEdit/TravelPlanEditPage.tsx
@@ -73,7 +73,7 @@ const TravelPlanEditPage = () => {
     setIsOpen(false);
   };
 
-  const { mutate: mutateTravelPlanEdit } = usePutTravelPlan();
+  const { mutate: mutateTravelPlanEdit, isPaused } = usePutTravelPlan();
 
   const handleEditTravelPlan = () => {
     const formattedStartDate = extractUTCDate(startDate);
@@ -95,6 +95,7 @@ const TravelPlanEditPage = () => {
   const debouncedEditTravelPlan = useLeadingDebounce(() => handleEditTravelPlan(), DEBOUNCED_TIME);
 
   const handleConfirmBottomSheet = () => {
+    if (isPaused) alert(ERROR_MESSAGE_MAP.network);
     debouncedEditTravelPlan();
   };
 

--- a/frontend/src/components/pages/travelPlanEdit/TravelPlanEditPage.tsx
+++ b/frontend/src/components/pages/travelPlanEdit/TravelPlanEditPage.tsx
@@ -37,7 +37,7 @@ const TravelPlanEditPage = () => {
   const location = useLocation();
   const id = extractID(location.pathname);
 
-  const { data, status, error } = useGetTravelPlan(id);
+  const { data, status, error, isLoading } = useGetTravelPlan(id);
 
   const [title, setTitle] = useState("");
 
@@ -127,6 +127,8 @@ const TravelPlanEditPage = () => {
     alert(errorMessage);
     navigate(ROUTE_PATHS_MAP.back);
   }
+
+  if (isLoading) <>Loadinggㅋㅋㅋㅋ</>;
 
   return (
     <>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -39,6 +39,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      retry: 0,
     },
   },
 });

--- a/frontend/src/queries/useInfiniteMyTravelPlans.ts
+++ b/frontend/src/queries/useInfiniteMyTravelPlans.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { TravelPlanResponse } from "@type/domain/travelPlan";
+import type { UserResponse } from "@type/domain/user";
 
 import { authClient } from "@apis/client";
 
@@ -21,27 +22,29 @@ export const getMyTravelPlans = async ({
   return response.data.content;
 };
 
-const useInfiniteMyTravelPlans = () => {
+const useInfiniteMyTravelPlans = (userData: UserResponse) => {
   const INITIAL_PAGE = 0;
   const DATA_LOAD_COUNT = 5;
 
-  const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: QUERY_KEYS_MAP.travelPlan.me(),
-    queryFn: ({ pageParam = INITIAL_PAGE }) => {
-      const page = pageParam;
-      const size = DATA_LOAD_COUNT;
-      return getMyTravelPlans({ page, size });
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) => {
-      const nextPage = lastPage.length ? allPages.length : undefined;
-      return nextPage;
-    },
-    select: (data) => ({
-      pages: data.pages.flatMap((page) => page),
-      pageParams: data.pageParams,
-    }),
-  });
+  const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage, isPaused } =
+    useInfiniteQuery({
+      queryKey: QUERY_KEYS_MAP.travelPlan.me(),
+      queryFn: ({ pageParam = INITIAL_PAGE }) => {
+        const page = pageParam;
+        const size = DATA_LOAD_COUNT;
+        return getMyTravelPlans({ page, size });
+      },
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const nextPage = lastPage.length ? allPages.length : undefined;
+        return nextPage;
+      },
+      select: (data) => ({
+        pages: data.pages.flatMap((page) => page),
+        pageParams: data.pageParams,
+      }),
+      enabled: !!userData,
+    });
 
   return {
     myTravelPlans: data?.pages || [],
@@ -50,6 +53,7 @@ const useInfiniteMyTravelPlans = () => {
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
+    isPaused,
   };
 };
 

--- a/frontend/src/queries/useInfiniteMyTravelogues.ts
+++ b/frontend/src/queries/useInfiniteMyTravelogues.ts
@@ -25,7 +25,6 @@ const useInfiniteMyTravelogues = () => {
   const INITIAL_PAGE = 0;
   const DATA_LOAD_COUNT = 5;
 
-  const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage } = useInfiniteQuery({
     queryKey: QUERY_KEYS_MAP.travelogue.me(),
     queryFn: ({ pageParam = INITIAL_PAGE }) => {
       const page = pageParam;
@@ -42,6 +41,7 @@ const useInfiniteMyTravelogues = () => {
       pageParams: data.pageParams,
     }),
   });
+  const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage, isPaused } =
 
   return {
     myTravelogues: data?.pages || [],
@@ -50,6 +50,7 @@ const useInfiniteMyTravelogues = () => {
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
+    isPaused,
   };
 };
 

--- a/frontend/src/queries/useInfiniteMyTravelogues.ts
+++ b/frontend/src/queries/useInfiniteMyTravelogues.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { MyTravelogue } from "@type/domain/travelogue";
+import type { UserResponse } from "@type/domain/user";
 
 import { authClient } from "@apis/client";
 
@@ -21,27 +22,29 @@ export const getMyTravelogues = async ({
   return response.data.content;
 };
 
-const useInfiniteMyTravelogues = () => {
+const useInfiniteMyTravelogues = (userData: UserResponse) => {
   const INITIAL_PAGE = 0;
   const DATA_LOAD_COUNT = 5;
 
-    queryKey: QUERY_KEYS_MAP.travelogue.me(),
-    queryFn: ({ pageParam = INITIAL_PAGE }) => {
-      const page = pageParam;
-      const size = DATA_LOAD_COUNT;
-      return getMyTravelogues({ page, size });
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) => {
-      const nextPage = lastPage.length ? allPages.length : undefined;
-      return nextPage;
-    },
-    select: (data) => ({
-      pages: data.pages.flatMap((page) => page),
-      pageParams: data.pageParams,
-    }),
-  });
   const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage, isPaused } =
+    useInfiniteQuery({
+      queryKey: QUERY_KEYS_MAP.travelogue.me(),
+      queryFn: ({ pageParam = INITIAL_PAGE }) => {
+        const page = pageParam;
+        const size = DATA_LOAD_COUNT;
+        return getMyTravelogues({ page, size });
+      },
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const nextPage = lastPage.length ? allPages.length : undefined;
+        return nextPage;
+      },
+      select: (data) => ({
+        pages: data.pages.flatMap((page) => page),
+        pageParams: data.pageParams,
+      }),
+      enabled: !!userData,
+    });
 
   return {
     myTravelogues: data?.pages || [],

--- a/frontend/src/queries/useInfiniteSearchTravelogues.ts
+++ b/frontend/src/queries/useInfiniteSearchTravelogues.ts
@@ -14,7 +14,7 @@ export const getSearchTravelogues = async ({
   size: number;
   keyword: string;
 }) => {
-  const response = await client.get(API_ENDPOINT_MAP.searchTravelogues, {
+  const response = await client.get(API_ENDPOINT_MAP.searchTravelogues + "ㅋㅋ", {
     params: { page, size, keyword },
   });
 
@@ -25,24 +25,25 @@ const useInfiniteSearchTravelogues = (keyword: string) => {
   const INITIAL_PAGE = 0;
   const DATA_LOAD_COUNT = 5;
 
-  const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: QUERY_KEYS_MAP.travelogue.search(keyword),
-    queryFn: ({ pageParam = INITIAL_PAGE }) => {
-      const page = pageParam;
-      const size = DATA_LOAD_COUNT;
-      return getSearchTravelogues({ page, size, keyword });
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) => {
-      const nextPage = lastPage.length ? allPages.length : undefined;
-      return nextPage;
-    },
-    select: (data) => ({
-      pages: data.pages.flatMap((page) => page),
-      pageParams: data.pageParams,
-    }),
-    enabled: keyword.trim() !== "",
-  });
+  const { data, status, error, fetchNextPage, isFetchingNextPage, hasNextPage, isPaused } =
+    useInfiniteQuery({
+      queryKey: QUERY_KEYS_MAP.travelogue.search(keyword),
+      queryFn: ({ pageParam = INITIAL_PAGE }) => {
+        const page = pageParam;
+        const size = DATA_LOAD_COUNT;
+        return getSearchTravelogues({ page, size, keyword });
+      },
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const nextPage = lastPage.length ? allPages.length : undefined;
+        return nextPage;
+      },
+      select: (data) => ({
+        pages: data.pages.flatMap((page) => page),
+        pageParams: data.pageParams,
+      }),
+      enabled: keyword.trim() !== "",
+    });
 
   return {
     travelogues: data?.pages || [],
@@ -51,6 +52,7 @@ const useInfiniteSearchTravelogues = (keyword: string) => {
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
+    isPaused,
   };
 };
 

--- a/frontend/src/queries/usePutTravelPlan.ts
+++ b/frontend/src/queries/usePutTravelPlan.ts
@@ -25,7 +25,7 @@ export const usePutTravelPlan = () => {
     unknown
   >({
     mutationFn: ({ travelPlan, id }) =>
-      authClient.put(API_ENDPOINT_MAP.travelPlanDetail(id), {
+      authClient.put(API_ENDPOINT_MAP.travelPlanDetail(id) + "zz", {
         ...travelPlan,
         days: travelPlan.days.map((day) => {
           return {

--- a/frontend/src/queries/usePutTravelPlan.ts
+++ b/frontend/src/queries/usePutTravelPlan.ts
@@ -25,7 +25,7 @@ export const usePutTravelPlan = () => {
     unknown
   >({
     mutationFn: ({ travelPlan, id }) =>
-      authClient.put(API_ENDPOINT_MAP.travelPlanDetail(id) + "zz", {
+      authClient.put(API_ENDPOINT_MAP.travelPlanDetail(id), {
         ...travelPlan,
         days: travelPlan.days.map((day) => {
           return {


### PR DESCRIPTION
# ✅ 작업 내용

여행 계획 수정, 마이페이지, 검색 페이지 → 리버

- 마이페이지
    - 닉네임 수정
        - 네트워크 오류 : 런타임에러 없이 걍 원래 닉넴으로 돌아감 (isPaused에 대한 처리 안함)
        - 서버 오류 : 서버에 문제 발생 alert 잘뜨고 원래 화면으로 돌아감
        - 로딩 중 : 빈화면 보이는 경우 없음
    - 내 정보 불러오기
        
        - 네트워크 오류 : → 이 상황 만드는게 더 힘들다, 네트워크 오류는 내 여행 계획, 내여행기에도 해놔서 내 정보에 까지 해놓을 필요 없음.
        - 서버 오류 :  서버 오류시  alert 뜬다.
        - 로딩 중 : 스켈레톤 잘뜸
    - 내 여행계획 불러오기
        - 내 정보 불러오기 성공해야먄 get 요청을 보낸다. (enabled)
        - 네트워크 오류 : isPaused 처리함
        - 서버 오류 :  error있으면 alert(error.message)
        - 로딩 중 : 스켈레톤 잘뜸
    - 내 여행기 불러오기
        - 내 정보 불러오기 성공해야먄 get 요청을 보낸다.  (enabled)
        - 네트워크 오류 : isPaused 처리함
        - 서버 오류 :  error있으면 alert(error.message)
        - 로딩 중 : 스켈레톤 잘뜸
- 여행 계획 수정
    - 네트워크 오류
        - useGetTravelPlan의 isPaused는 따지지 않음. ( 마이 페이지에서 내정보 불러오기의 isPaused 분기처리하지 않음
        - 수정 확인 버튼 눌렀을 때 , usePutTravelPlan의 isPaused가 true이면 alert창 뜨게함
    - 서버 오류
        - usePut, get :  alert 처리되있ㅇ믐
    - 로딩 중 
        - 스켈레톤 미적용상태인데 괜찮은듯
- 검색 페이지
    - 네트워크 오류
        - alert
    - 서버 오류
        - 검색 에러날시 alert + 휑
    - 로딩 중
        - 스켈레톤 너무잘됨

# 📸 스크린샷

# 🙈 참고 사항
