### PR TITLE
[Feature] - 데모데이 피드백 반영(지니)

### DIFF
--- a/frontend/cypress/e2e/travelPlanRegister.cy.ts
+++ b/frontend/cypress/e2e/travelPlanRegister.cy.ts
@@ -151,7 +151,7 @@ describe("여행 계획 등록 테스트", () => {
       cy.get(CYPRESS_SELECTOR_MAP.accordion.item).should("not.exist");
     });
 
-    it("장소 추가하기 버튼을 누르고 장소를 추가할 수 있다.", () => {
+    it.only("장소 추가하기 버튼을 누르고 장소를 추가할 수 있다.", () => {
       // given
       const INPUT_VALUE = "도쿄";
 
@@ -164,7 +164,7 @@ describe("여행 계획 등록 테스트", () => {
 
       // when
       cy.get(CYPRESS_SELECTOR_MAP.googleSearchPopup.searchInput).type(INPUT_VALUE);
-      cy.get(".pac-item").first().click();
+      cy.get(".pac-item").first().click({ force: true });
 
       // then
       cy.get(CYPRESS_SELECTOR_MAP.googleSearchPopup.container).should("not.exist");

--- a/frontend/cypress/e2e/travelPlanRegister.cy.ts
+++ b/frontend/cypress/e2e/travelPlanRegister.cy.ts
@@ -151,7 +151,7 @@ describe("여행 계획 등록 테스트", () => {
       cy.get(CYPRESS_SELECTOR_MAP.accordion.item).should("not.exist");
     });
 
-    it.only("장소 추가하기 버튼을 누르고 장소를 추가할 수 있다.", () => {
+    it("장소 추가하기 버튼을 누르고 장소를 추가할 수 있다.", () => {
       // given
       const INPUT_VALUE = "도쿄";
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "lint:styled": "stylelint './src/**/*.styled.ts' --fix",
     "test": "jest --passWithNoTests",
     "test-e2e": "cypress open",
-    "test-e2e:run": "cypress run",
+    "test-e2e:run": "cypress run --browser chrome",
     "storybook": "storybook dev -p 6006",
     "lint": "eslint src/",
     "build-storybook": "storybook build"

--- a/frontend/src/components/common/Calendar/Calendar.styled.ts
+++ b/frontend/src/components/common/Calendar/Calendar.styled.ts
@@ -68,8 +68,8 @@ export const DayCell = styled.td<{ $isCurrentMonth: boolean; $isSelectable: bool
       }
     `};
 
-  color: ${({ theme, $isCurrentMonth }) =>
-    $isCurrentMonth ? theme.colors.text.secondary : PRIMITIVE_COLORS.gray[300]};
+  color: ${({ theme, $isCurrentMonth, $isSelectable }) =>
+    $isCurrentMonth && $isSelectable ? theme.colors.text.secondary : PRIMITIVE_COLORS.gray[300]};
   text-align: center;
 `;
 

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -75,7 +75,7 @@ const Calendar = ({
               onClick={() => isSelectable && onSelectDate(date)}
               data-cy={CYPRESS_DATA_MAP.calendar.dayCell}
             >
-              <Text textType="detail">{date.getDate()}</Text>
+              <Text textType="detail">{isCurrentMonth ? date.getDate() : ""}</Text>
             </S.DayCell>
           );
         })}

--- a/frontend/src/components/common/GoogleMapView/GoogleMapView.constant.ts
+++ b/frontend/src/components/common/GoogleMapView/GoogleMapView.constant.ts
@@ -1,0 +1,22 @@
+export const GOOGLE_MAP_CONTAINER_STYLE = {
+  width: "100%",
+  height: "23rem",
+};
+
+export const INIT_CENTER_POSITION = {
+  lat: 37.5665,
+  lng: 126.978,
+};
+
+export const GOOGLE_MAP_OPTIONS = {
+  disableDefaultUI: true,
+  styles: [
+    {
+      featureType: "poi",
+      elementType: "labels",
+      stylers: [{ visibility: "off" }],
+    },
+  ],
+};
+
+export const POLYLINE_OPTIONS = { strokeColor: "#72A2FFCC", strokeWeight: 3 };

--- a/frontend/src/components/common/GoogleMapView/GoogleMapView.tsx
+++ b/frontend/src/components/common/GoogleMapView/GoogleMapView.tsx
@@ -1,16 +1,20 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useCallback } from "react";
+import { memo } from "react";
 
 import { GoogleMap, MarkerF, Polyline } from "@react-google-maps/api";
 
-import theme from "@styles/theme";
+import {
+  GOOGLE_MAP_CONTAINER_STYLE,
+  GOOGLE_MAP_OPTIONS,
+  POLYLINE_OPTIONS,
+} from "@components/common/GoogleMapView/GoogleMapView.constant";
+import {
+  calculateCenter,
+  createMarkerLabelStyle,
+} from "@components/common/GoogleMapView/GoogleMapView.util";
+
+import useGoogleMap from "@hooks/useGoogleMap";
 
 import { markerUrl } from "@assets/svg";
-
-const containerStyle = {
-  width: "100%",
-  height: "23rem",
-};
 
 interface GoogleMapViewProps {
   places: {
@@ -19,72 +23,44 @@ interface GoogleMapViewProps {
   }[];
 }
 
-const calculateCenter = (places: { lat: number; lng: number }[]): { lat: number; lng: number } => {
-  const latSum = places.reduce((sum, place) => sum + place.lat, 0);
-  const lngSum = places.reduce((sum, place) => sum + place.lng, 0);
-  const count = places.length;
-
-  return {
-    lat: latSum / count,
-    lng: lngSum / count,
-  };
-};
-
 const GoogleMapView = ({ places }: GoogleMapViewProps) => {
+  console.log(places);
   const center = calculateCenter(places);
 
-  const onLoad = useCallback(
-    (map: google.maps.Map) => {
-      const bounds = new window.google.maps.LatLngBounds();
-      places.forEach((place) => {
-        bounds.extend(new window.google.maps.LatLng(place.lat, place.lng));
-      });
-      map.fitBounds(bounds);
-    },
-    [places],
-  );
+  const { onLoad, onUnmount, onBoundsChanged } = useGoogleMap(places);
+
+  /**
+   * 컴포넌트 내부에 위치시키지 않으면 "Uncaught TypeError: Cannot read properties of undefined (reading 'maps')"
+   * 에러가 발생하여 다음과 같은 위치로 변경
+   */
+  const MARKER_ICON_STYLE = {
+    url: markerUrl,
+    scaledSize: new window.google.maps.Size(30, 30),
+    labelOrigin: new window.google.maps.Point(15, -10),
+  };
 
   return (
     <div>
       <GoogleMap
-        options={{
-          disableDefaultUI: true,
-          styles: [
-            {
-              featureType: "poi",
-              elementType: "labels",
-              stylers: [{ visibility: "off" }],
-            },
-          ],
-        }}
-        mapContainerStyle={containerStyle}
+        options={GOOGLE_MAP_OPTIONS}
+        mapContainerStyle={GOOGLE_MAP_CONTAINER_STYLE}
         center={center}
-        zoom={10}
         onLoad={onLoad}
+        onUnmount={onUnmount}
+        onBoundsChanged={onBoundsChanged}
       >
-        {places.map((position, index) => (
-          <MarkerF key={`${index}-${position.lat}`} position={position} icon={markerUrl} />
-        ))}
         {places.map((position, index) => (
           <MarkerF
             key={`marker-${index}-${position.lat}-${position.lng}`}
             position={position}
-            icon={{
-              url: markerUrl,
-              scaledSize: new window.google.maps.Size(30, 30),
-              labelOrigin: new window.google.maps.Point(15, -10),
-            }}
-            label={{
-              text: `${index + 1}`,
-              color: theme.colors.primary,
-              fontSize: "1.4rem",
-            }}
+            icon={MARKER_ICON_STYLE}
+            label={createMarkerLabelStyle(index)}
           />
         ))}
-        <Polyline path={places} options={{ strokeColor: "#72A2FFCC", strokeWeight: 3 }} />
+        <Polyline path={places} options={POLYLINE_OPTIONS} />
       </GoogleMap>
     </div>
   );
 };
 
-export default React.memo(GoogleMapView);
+export default memo(GoogleMapView);

--- a/frontend/src/components/common/GoogleMapView/GoogleMapView.tsx
+++ b/frontend/src/components/common/GoogleMapView/GoogleMapView.tsx
@@ -24,7 +24,6 @@ interface GoogleMapViewProps {
 }
 
 const GoogleMapView = ({ places }: GoogleMapViewProps) => {
-  console.log(places);
   const center = calculateCenter(places);
 
   const { onLoad, onUnmount, onBoundsChanged } = useGoogleMap(places);

--- a/frontend/src/components/common/GoogleMapView/GoogleMapView.util.ts
+++ b/frontend/src/components/common/GoogleMapView/GoogleMapView.util.ts
@@ -1,0 +1,27 @@
+import { INIT_CENTER_POSITION } from "@components/common/GoogleMapView/GoogleMapView.constant";
+
+import theme from "@styles/theme";
+
+export const calculateCenter = (
+  places: { lat: number; lng: number }[],
+): { lat: number; lng: number } => {
+  if (places.length === 0) {
+    return { lat: INIT_CENTER_POSITION.lat, lng: INIT_CENTER_POSITION.lng };
+  }
+  const latSum = places.reduce((sum, place) => sum + place.lat, 0);
+  const lngSum = places.reduce((sum, place) => sum + place.lng, 0);
+  const count = places.length;
+
+  return {
+    lat: latSum / count,
+    lng: lngSum / count,
+  };
+};
+
+export const createMarkerLabelStyle = (markerOrder: number) => {
+  return {
+    text: `${markerOrder + 1}`,
+    color: theme.colors.primary,
+    fontSize: "1.4rem",
+  };
+};

--- a/frontend/src/components/common/Input/Input.styled.ts
+++ b/frontend/src/components/common/Input/Input.styled.ts
@@ -25,6 +25,7 @@ export const Input = styled.input<{ variant: InputVariants }>`
 
   ${({ theme }) => theme.typography.mobile.detail}
   color: ${({ theme }) => theme.colors.text.primary};
+  font-size: 1.6rem;
 
   &:disabled {
     background-color: ${({ theme }) => theme.colors.background.disabled};

--- a/frontend/src/hooks/pages/useTravelPlanDays.ts
+++ b/frontend/src/hooks/pages/useTravelPlanDays.ts
@@ -124,7 +124,7 @@ export const useTravelPlanDays = (days: TravelTransformPlaces[]) => {
         const travelPlanPlace = previousTravelPlanDays[dayIndex]?.places[placeIndex];
 
         if (travelPlanPlace?.todos) {
-          travelPlanPlace.todos.splice(Number(todoId), 1);
+          travelPlanPlace.todos = travelPlanPlace.todos.filter((todo) => todo.id !== todoId);
         }
       });
     },

--- a/frontend/src/hooks/useGoogleMap.ts
+++ b/frontend/src/hooks/useGoogleMap.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+
+import { MapPosition } from "@type/domain/common";
+
+const INIT_CENTER_POSITION = {
+  lat: 37.5665,
+  lng: 126.978,
+};
+
+const useGoogleMap = (places: MapPosition[]) => {
+  const [googleMap, setGoogleMap] = useState<google.maps.Map | null>(null);
+
+  const onLoad = useCallback((map: google.maps.Map) => {
+    setGoogleMap(map);
+  }, []);
+
+  const onUnmount = useCallback(() => {
+    setGoogleMap(null);
+  }, []);
+
+  const onBoundsChanged = useCallback(() => {
+    if (googleMap) {
+      if (places.length === 0) {
+        googleMap.setCenter(INIT_CENTER_POSITION);
+        googleMap.setZoom(7);
+      } else {
+        const bounds = new window.google.maps.LatLngBounds();
+        places.forEach((place) => {
+          bounds.extend(new window.google.maps.LatLng(place.lat, place.lng));
+        });
+        googleMap.fitBounds(bounds);
+      }
+    }
+  }, [places, googleMap]);
+
+  return {
+    onLoad,
+    onUnmount,
+    onBoundsChanged,
+  };
+};
+
+export default useGoogleMap;


### PR DESCRIPTION
# ✅ 작업 내용
- 지도 기본위치 서울로 고정
- 검색, 입력창 눌렀을 때 확대되지 않도록 변경
- 캘린더 ui 내 지난 날짜에 대한 ui 피드백을 제공하도록 변경(이전 달 보여지는 부분 제거 및 지난 날짜는 gray text로 변경)

# 📸 스크린샷
x

# 🙈 참고 사항
- top button(스크롤을 많이 내렸을 때 최상단으로 이동)의 경우 팀원들과 이야기가 더 필요할거 같아 따로 작업하진 않았습니다.
- meta 태그에 user-scalable="no"로도 확대 하지 않을 수 있지만 이 경우 접근성 문제가 발생해서 이를 해결하기 위한 다른 방법들을 찾다가 Input의 font-size를 16px로 변경했습니다.
- GoogleMapView에 대한 전반적인 리팩터링을 추가적으로 진행했습니다. (custom hook 분리, util 함수 및 상수 분리)
- e2e 테스트를 msw 핸들러가 있는 상태로 실행하면 테스트 통과가 되지 않는 문제를 확인했습니다! (그래서 msw 핸들러를 제거한채로 테스트를 일단 진행해주세요 :))
- 이 pr에서 cypress 관련 로직이 추가되어있습니다,,, (it.only 제거)