### PR TITLE
[Feature] - 여행기 정렬 및 날짜별 필터링 추가

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.List;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.dto.ExceptionResponse;
+import kr.touroot.travelogue.dto.request.TravelogueFilterCondition;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
 import kr.touroot.travelogue.dto.response.TravelogueLikeResponse;
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "여행기")
@@ -141,32 +140,13 @@ public class TravelogueController {
     public ResponseEntity<Page<TravelogueSimpleResponse>> findMainPageTravelogues(
             @Parameter(hidden = true)
             @PageableDefault(size = 5, sort = "id", direction = Direction.DESC)
-            Pageable pageable
-    ) {
-        return ResponseEntity.ok(travelogueFacadeService.findSimpleTravelogues(pageable));
-    }
-
-    @Operation(summary = "여행기 메인 페이지 필터링")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "요청이 정상적으로 처리되었을 때"
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "올바르지 않은 페이지네이션 옵션으로 요청했을 때",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
-            ),
-    })
-    @PageableAsQueryParam
-    @GetMapping(params = {"tag-filter"})
-    public ResponseEntity<Page<TravelogueSimpleResponse>> findMainPageTravelogues(
-            @Parameter(hidden = true)
-            @PageableDefault(size = 5, sort = "id", direction = Direction.DESC)
             Pageable pageable,
-            @RequestParam(name = "tag-filter", required = false) List<Long> tagFilter
+            TravelogueFilterCondition filter
     ) {
-        return ResponseEntity.ok(travelogueFacadeService.findSimpleTravelogues(tagFilter, pageable));
+        if (filter.isNoCondition()) {
+            return ResponseEntity.ok(travelogueFacadeService.findSimpleTravelogues(pageable));
+        }
+        return ResponseEntity.ok(travelogueFacadeService.findSimpleTravelogues(filter, pageable));
     }
 
     @Operation(summary = "여행기 검색")

--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -35,6 +35,7 @@ public class Travelogue extends BaseEntity {
 
     private static final int MIN_TITLE_LENGTH = 1;
     private static final int MAX_TITLE_LENGTH = 20;
+    private static final int LIKE_COUNT_WEIGHT = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -106,6 +107,14 @@ public class Travelogue extends BaseEntity {
         } catch (Exception e) {
             throw new BadRequestException("이미지 url 형식이 잘못되었습니다");
         }
+    }
+    
+    public void increaseLikeCount() {
+        likeCount += LIKE_COUNT_WEIGHT;
+    }
+    
+    public void decreaseLikeCount() {
+        likeCount -= LIKE_COUNT_WEIGHT;
     }
 
     public boolean isAuthor(Member author) {

--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -52,12 +52,12 @@ public class Travelogue extends BaseEntity {
 
     @Column(nullable = false)
     @ColumnDefault("0")
-    private Integer likeCount;
+    private Long likeCount;
 
     @OneToMany(mappedBy = "travelogue", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravelogueDay> travelogueDays = new ArrayList<>();
 
-    private Travelogue(Long id, Member author, String title, String thumbnail, Integer likeCount) {
+    private Travelogue(Long id, Member author, String title, String thumbnail, Long likeCount) {
         validate(author, title, thumbnail);
         this.id = id;
         this.author = author;
@@ -67,7 +67,7 @@ public class Travelogue extends BaseEntity {
     }
 
     public Travelogue(Member author, String title, String thumbnail) {
-        this(null, author, title, thumbnail, 0);
+        this(null, author, title, thumbnail, 0L);
     }
 
     public void update(String title, String thumbnail) {

--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -49,19 +50,24 @@ public class Travelogue extends BaseEntity {
     @Column(nullable = false)
     private String thumbnail;
 
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer likeCount;
+
     @OneToMany(mappedBy = "travelogue", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravelogueDay> travelogueDays = new ArrayList<>();
 
-    public Travelogue(Long id, Member author, String title, String thumbnail) {
+    private Travelogue(Long id, Member author, String title, String thumbnail, Integer likeCount) {
         validate(author, title, thumbnail);
         this.id = id;
         this.author = author;
         this.title = title;
         this.thumbnail = thumbnail;
+        this.likeCount = likeCount;
     }
 
     public Travelogue(Member author, String title, String thumbnail) {
-        this(null, author, title, thumbnail);
+        this(null, author, title, thumbnail, 0);
     }
 
     public void update(String title, String thumbnail) {

--- a/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueFilterCondition.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueFilterCondition.java
@@ -1,0 +1,10 @@
+package kr.touroot.travelogue.dto.request;
+
+import java.util.List;
+
+public record TravelogueFilterCondition(List<Long> tag, Integer period) {
+
+    public boolean isNoCondition() {
+        return tag == null && period == null;
+    }
+}

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueLikeRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelogueLikeRepository extends JpaRepository<TravelogueLike, Long> {
 
-    Long countByTravelogue(Travelogue travelogue);
-
     boolean existsByTravelogueAndLiker(Travelogue travelogue, Member liker);
 
     void deleteAllByTravelogue(Travelogue travelogue);

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
@@ -9,5 +9,5 @@ public interface TravelogueQueryRepository {
 
     Page<Travelogue> findByTitleContaining(String keyword, Pageable pageable);
 
-    Page<Travelogue> findAllByTag(TravelogueFilterCondition filter, Pageable pageable);
+    Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
@@ -1,7 +1,7 @@
 package kr.touroot.travelogue.repository.query;
 
-import java.util.List;
 import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.dto.request.TravelogueFilterCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,5 +9,5 @@ public interface TravelogueQueryRepository {
 
     Page<Travelogue> findByTitleContaining(String keyword, Pageable pageable);
 
-    Page<Travelogue> findAllByTag(List<Long> tagFilter, Pageable pageable);
+    Page<Travelogue> findAllByTag(TravelogueFilterCondition filter, Pageable pageable);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
@@ -3,15 +3,18 @@ package kr.touroot.travelogue.repository.query;
 import static kr.touroot.travelogue.domain.QTravelogue.travelogue;
 import static kr.touroot.travelogue.domain.QTravelogueTag.travelogueTag;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.dto.request.TravelogueFilterCondition;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -34,18 +37,30 @@ public class TravelogueQueryRepositoryImpl implements TravelogueQueryRepository 
     }
 
     @Override
-    public Page<Travelogue> findAllByTag(List<Long> tagFilter, Pageable pageable) {
+    public Page<Travelogue> findAllByTag(TravelogueFilterCondition filter, Pageable pageable) {
         List<Travelogue> results = jpaQueryFactory.select(travelogue)
                 .from(travelogueTag)
-                .where(travelogueTag.tag.id.in(tagFilter))
+                .where(travelogueTag.tag.id.in(filter.tag()))
                 .groupBy(travelogueTag.travelogue)
-                .having(isSameCountWithFilter(tagFilter))
-                .orderBy(travelogueTag.travelogue.createdAt.desc())
+                .having(isSameCountWithFilter(filter.tag()))
+                .orderBy(findSortCondition(pageable.getSort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         return new PageImpl<>(results, pageable, results.size());
+    }
+
+    private OrderSpecifier<?> findSortCondition(Sort sort) {
+        Sort.Order order = sort.iterator()
+                .next();
+        String sortBy = order.getProperty();
+
+        if (sortBy.equals("likeCount")) {
+            return travelogueTag.travelogue.likeCount.desc();
+        }
+
+        return travelogueTag.travelogue.createdAt.desc();
     }
 
     private BooleanExpression isSameCountWithFilter(List<Long> tagFilter) {

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -12,6 +12,7 @@ import kr.touroot.travelogue.domain.TravelogueDay;
 import kr.touroot.travelogue.domain.TraveloguePhoto;
 import kr.touroot.travelogue.domain.TraveloguePlace;
 import kr.touroot.travelogue.dto.request.TravelogueDayRequest;
+import kr.touroot.travelogue.dto.request.TravelogueFilterCondition;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
@@ -137,8 +138,8 @@ public class TravelogueFacadeService {
     }
 
     @Transactional(readOnly = true)
-    public Page<TravelogueSimpleResponse> findSimpleTravelogues(List<Long> tagFilter, Pageable pageable) {
-        Page<Travelogue> travelogues = travelogueService.findAllByFilter(tagFilter, pageable);
+    public Page<TravelogueSimpleResponse> findSimpleTravelogues(TravelogueFilterCondition filter, Pageable pageable) {
+        Page<Travelogue> travelogues = travelogueService.findAllByFilter(filter, pageable);
         return travelogues.map(this::getTravelogueSimpleResponse);
     }
 

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -32,9 +32,10 @@ public class TravelogueLikeService {
         if (notExists) {
             TravelogueLike travelogueLike = new TravelogueLike(travelogue, liker);
             travelogueLikeRepository.save(travelogueLike);
+            travelogue.increaseLikeCount();
         }
 
-        return new TravelogueLikeResponse(true, travelogueLikeRepository.countByTravelogue(travelogue));
+        return new TravelogueLikeResponse(true, travelogue.getLikeCount());
     }
 
     @Transactional
@@ -42,9 +43,10 @@ public class TravelogueLikeService {
         boolean exists = travelogueLikeRepository.existsByTravelogueAndLiker(travelogue, liker);
         if (exists) {
             travelogueLikeRepository.deleteByTravelogueAndLiker(travelogue, liker);
+            travelogue.decreaseLikeCount();
         }
 
-        return new TravelogueLikeResponse(false, travelogueLikeRepository.countByTravelogue(travelogue));
+        return new TravelogueLikeResponse(false, travelogue.getLikeCount());
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -17,13 +17,13 @@ public class TravelogueLikeService {
 
     @Transactional(readOnly = true)
     public TravelogueLikeResponse findLikeByTravelogue(Travelogue travelogue) {
-        return new TravelogueLikeResponse(false, travelogueLikeRepository.countByTravelogue(travelogue));
+        return new TravelogueLikeResponse(false, travelogue.getLikeCount());
     }
 
     @Transactional(readOnly = true)
     public TravelogueLikeResponse findLikeByTravelogueAndLiker(Travelogue travelogue, Member liker) {
         boolean exists = travelogueLikeRepository.existsByTravelogueAndLiker(travelogue, liker);
-        return new TravelogueLikeResponse(exists, travelogueLikeRepository.countByTravelogue(travelogue));
+        return new TravelogueLikeResponse(exists, travelogue.getLikeCount());
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -6,6 +6,7 @@ import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.dto.request.TravelogueFilterCondition;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.repository.query.TravelogueQueryRepository;
 import kr.touroot.travelogue.repository.TravelogueRepository;
@@ -52,7 +53,7 @@ public class TravelogueService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Travelogue> findAllByFilter(List<Long> filter, Pageable pageable) {
+    public Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable) {
         return travelogueQueryRepository.findAllByTag(filter, pageable);
     }
 

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -1,6 +1,5 @@
 package kr.touroot.travelogue.service;
 
-import java.util.List;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.image.infrastructure.AwsS3Provider;
@@ -54,7 +53,7 @@ public class TravelogueService {
 
     @Transactional(readOnly = true)
     public Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable) {
-        return travelogueQueryRepository.findAllByTag(filter, pageable);
+        return travelogueQueryRepository.findAllByFilter(filter, pageable);
     }
 
     @Transactional

--- a/backend/src/test/java/kr/touroot/authentication/controller/LoginControllerTest.java
+++ b/backend/src/test/java/kr/touroot/authentication/controller/LoginControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
+@DisplayName("로그인 컨트롤러")
 @AcceptanceTest
 class LoginControllerTest {
 

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -497,12 +497,12 @@ class TravelogueControllerTest {
     @DisplayName("여행기에 좋아요 취소를 한다.")
     @Test
     void unlikeTravelogue() throws JsonProcessingException {
-        testHelper.initTravelogueTestDataWithLike(member);
+        Travelogue travelogue = testHelper.initTravelogueTestDataWithLike(member);
         TravelogueLikeResponse response = new TravelogueLikeResponse(false, 0L);
 
         RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .when().delete("/api/v1/travelogues/1/like")
+                .when().delete("/api/v1/travelogues/" + travelogue.getId() +"/like")
                 .then().log().all()
                 .statusCode(200).assertThat()
                 .body(is(objectMapper.writeValueAsString(response)));

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -306,15 +306,15 @@ class TravelogueControllerTest {
                 .body(is(objectMapper.writeValueAsString(responses)));
     }
 
-    @DisplayName("메인 페이지 조회 시, 최신 작성 순으로 여행기를 조회한다.")
+    @DisplayName("메인 페이지 조회 시 태그 기반으로 필터링을 진행한다.")
     @Test
-    void filterMainPageTravelogues() throws JsonProcessingException {
+    void filterMainPageTravelogues() {
         testHelper.initAllTravelogueTestData();
         testHelper.initTravelogueTestDataWithTag(member, List.of(TagFixture.TAG_2.get(), TagFixture.TAG_3.get()));
 
         RestAssured.given().log().all()
                 .accept(ContentType.JSON)
-                .params("tag-filter", "2,3")
+                .params("tag", "2,3")
                 .when().get("/api/v1/travelogues")
                 .then().log().all()
                 .statusCode(200).assertThat()

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -306,6 +306,21 @@ class TravelogueControllerTest {
                 .body(is(objectMapper.writeValueAsString(responses)));
     }
 
+    @DisplayName("메인 페이지 조회 시, 좋아요 순으로 여행기를 조회한다.")
+    @Test
+    void findMainPageTraveloguesOrderByLikeCount() throws JsonProcessingException {
+        testHelper.initAllTravelogueTestData();
+        Page<TravelogueSimpleResponse> responses = TravelogueResponseFixture.getTravelogueSimpleResponsesOrderByLikeCount();
+
+        RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .params("sort", "likeCount,desc")
+                .when().get("/api/v1/travelogues")
+                .then().log().all()
+                .statusCode(200).assertThat()
+                .body(is(objectMapper.writeValueAsString(responses)));
+    }
+
     @DisplayName("메인 페이지 조회 시 태그 기반으로 필터링을 진행한다.")
     @Test
     void filterMainPageTravelogues() {

--- a/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
+++ b/backend/src/test/java/kr/touroot/travelogue/fixture/TravelogueResponseFixture.java
@@ -110,6 +110,31 @@ public class TravelogueResponseFixture {
         return new PageImpl<>(responses, PageRequest.of(0, 5, Sort.by(Direction.DESC, "id")), responses.size());
     }
 
+    public static Page<TravelogueSimpleResponse> getTravelogueSimpleResponsesOrderByLikeCount() {
+        List<TravelogueSimpleResponse> responses = List.of(
+                TravelogueSimpleResponse.builder()
+                        .id(1L)
+                        .title("제주에 하영 옵서")
+                        .authorNickname("리비")
+                        .authorProfileUrl("https://dev.touroot.kr/temporary/profile.png")
+                        .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
+                        .tags(List.of())
+                        .likeCount(1L)
+                        .build(),
+                TravelogueSimpleResponse.builder()
+                        .id(2L)
+                        .title("제주에 하영 옵서")
+                        .authorNickname("리비")
+                        .authorProfileUrl("https://dev.touroot.kr/temporary/profile.png")
+                        .thumbnail("https://dev.touroot.kr/temporary/jeju_thumbnail.png")
+                        .tags(List.of(TagFixture.TAG_1.getResponse(1L)))
+                        .likeCount(0L)
+                        .build()
+        );
+
+        return new PageImpl<>(responses, PageRequest.of(0, 5, Sort.by(Direction.DESC, "id")), responses.size());
+    }
+
     public static List<TravelogueDayResponse> getTravelogueDayResponses() {
         return List.of(TravelogueDayResponse.builder()
                 .id(1L)

--- a/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelogue/helper/TravelogueTestHelper.java
@@ -180,6 +180,8 @@ public class TravelogueTestHelper {
 
     public TravelogueLike persistTravelogueLike(Travelogue travelogue, Member liker) {
         TravelogueLike like = new TravelogueLike(travelogue, liker);
+        travelogue.increaseLikeCount();
+        travelogueRepository.save(travelogue);
 
         return travelogueLikeRepository.save(like);
     }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -16,6 +16,7 @@ import kr.touroot.member.domain.Member;
 import kr.touroot.member.service.MemberService;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.dto.request.TravelogueDayRequest;
+import kr.touroot.travelogue.dto.request.TravelogueFilterCondition;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
@@ -164,10 +165,10 @@ class TravelogueFacadeServiceTest {
         // given
         testHelper.initAllTravelogueTestData();
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
-        List<Long> tagFilters = List.of(1L);
+        TravelogueFilterCondition filter = new TravelogueFilterCondition(List.of(1L), null);
 
         // when
-        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(tagFilters, pageRequest);
+        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(filter, pageRequest);
 
         // then
         assertThat(result.getContent()).hasSize(1);


### PR DESCRIPTION
# ✅ 작업 내용

- 여행기 좋아요 수 반정규화
- 여행기 정렬 기능 구현
- 날짜별 필터링 기능 구현

# 참고사항
- request param이 두개가 되고, 둘 다 옵셔널이 되면서 controller의 오버라이딩이 불가능해졌습니다. 기존에 사용하던 `@GetMapping(params=)`를 활용한 오버라이딩은 두 개 모두 존재할 때 사용할 수 있습니다. 따라서 컨트롤러에 if 분기 로직이 들어갔는데요, 분기로직을 서비스로 빼는게 나을지 의견 부탁드립니다.