### PR TITLE
[Fix] - 상세보기에서 좋아요 누를 때마다 지도 움직이는 문제 & 사용자가 지도를 확대하지 못하는 문제 해결

### DIFF
--- a/frontend/src/components/common/GoogleMapView/GoogleMapView.tsx
+++ b/frontend/src/components/common/GoogleMapView/GoogleMapView.tsx
@@ -26,7 +26,7 @@ interface GoogleMapViewProps {
 const GoogleMapView = ({ places }: GoogleMapViewProps) => {
   const center = calculateCenter(places);
 
-  const { onLoad, onUnmount, onBoundsChanged } = useGoogleMap(places);
+  const { onLoad, onUnmount } = useGoogleMap(places);
 
   /**
    * 컴포넌트 내부에 위치시키지 않으면 "Uncaught TypeError: Cannot read properties of undefined (reading 'maps')"
@@ -46,7 +46,6 @@ const GoogleMapView = ({ places }: GoogleMapViewProps) => {
         center={center}
         onLoad={onLoad}
         onUnmount={onUnmount}
-        onBoundsChanged={onBoundsChanged}
       >
         {places.map((position, index) => (
           <MarkerF

--- a/frontend/src/hooks/useGoogleMap.ts
+++ b/frontend/src/hooks/useGoogleMap.ts
@@ -33,6 +33,12 @@ const useGoogleMap = (places: MapPosition[]) => {
   useEffect(() => {
     if (!googleMap) return;
 
+    if (places.length === 1) {
+      const [place] = places;
+      googleMap.setCenter({ lat: place.lat, lng: place.lng });
+      googleMap.setZoom(9);
+    }
+
     if (places.length > 1) {
       fitMapToBounds(googleMap, places);
     }

--- a/frontend/src/hooks/useGoogleMap.ts
+++ b/frontend/src/hooks/useGoogleMap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { MapPosition } from "@type/domain/common";
 
@@ -7,10 +7,22 @@ const INIT_CENTER_POSITION = {
   lng: 126.978,
 };
 
+const fitMapToBounds = (map: google.maps.Map, locations: MapPosition[]) => {
+  const bounds = new window.google.maps.LatLngBounds();
+
+  locations.forEach((location) => {
+    bounds.extend(new window.google.maps.LatLng(location.lat, location.lng));
+  });
+
+  map.fitBounds(bounds);
+};
+
 const useGoogleMap = (places: MapPosition[]) => {
   const [googleMap, setGoogleMap] = useState<google.maps.Map | null>(null);
 
   const onLoad = useCallback((map: google.maps.Map) => {
+    map.setCenter(INIT_CENTER_POSITION);
+    map.setZoom(7);
     setGoogleMap(map);
   }, []);
 
@@ -18,25 +30,17 @@ const useGoogleMap = (places: MapPosition[]) => {
     setGoogleMap(null);
   }, []);
 
-  const onBoundsChanged = useCallback(() => {
-    if (googleMap) {
-      if (places.length === 0) {
-        googleMap.setCenter(INIT_CENTER_POSITION);
-        googleMap.setZoom(7);
-      } else {
-        const bounds = new window.google.maps.LatLngBounds();
-        places.forEach((place) => {
-          bounds.extend(new window.google.maps.LatLng(place.lat, place.lng));
-        });
-        googleMap.fitBounds(bounds);
-      }
+  useEffect(() => {
+    if (!googleMap) return;
+
+    if (places.length > 1) {
+      fitMapToBounds(googleMap, places);
     }
-  }, [places, googleMap]);
+  }, [googleMap, places]);
 
   return {
     onLoad,
     onUnmount,
-    onBoundsChanged,
   };
 };
 


### PR DESCRIPTION
# ✅ 작업 내용
- 상세보기에서 좋아요 누를 때마다 지도 움직이는 문제 해결
- 사용자가 지도를 확대하지 못하는 문제 해결
- 여행 장소가 1개일 때 zoom level 9로 변경

# 📸 스크린샷
x

# 🙈 참고 사항
- 한번 크로스 체킹해주시면 감사드리겠습니다~!
