### PR TITLE
[Fix] - 지도 장소명이 한국말이 아닌 영어로 나오는 이슈

### DIFF
--- a/frontend/src/components/common/GoogleMapLoadScript/GoogleMapLoadScript.tsx
+++ b/frontend/src/components/common/GoogleMapLoadScript/GoogleMapLoadScript.tsx
@@ -9,6 +9,7 @@ interface GoogleMapLoadScriptProps extends React.PropsWithChildren {
 const GoogleMapLoadScript = ({ children, loadingElement }: GoogleMapLoadScriptProps) => {
   const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY ?? "",
+    language: "ko",
     libraries: LIBRARIES,
   });
 


### PR DESCRIPTION
# ✅ 작업 내용

- 구글맵을 한국어로 받아오도록 수정함

# 📸 스크린샷

<img width="415" alt="스크린샷 2024-09-27 오후 12 37 31" src="https://github.com/user-attachments/assets/6711111e-74c4-4bec-baec-ef1bd646759f">


# 🙈 참고 사항
