### PR TITLE
[Fix] - 여행기 수정 시 썸네일을 임시 저장소에만 저장하는 버그 수정

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -6,9 +6,9 @@ import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueFilterCondition;
-import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.domain.search.SearchCondition;
 import kr.touroot.travelogue.domain.search.SearchType;
+import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
 import kr.touroot.travelogue.repository.TravelogueRepository;
 import kr.touroot.travelogue.repository.query.TravelogueQueryRepository;
@@ -68,7 +68,8 @@ public class TravelogueService {
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행기입니다."));
         validateAuthor(travelogue, author);
 
-        travelogue.update(request.title(), request.thumbnail());
+        String url = s3Provider.copyImageToPermanentStorage(request.thumbnail());
+        travelogue.update(request.title(), url);
 
         return travelogueRepository.save(travelogue);
     }

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -449,6 +449,9 @@ class TravelogueControllerTest {
     @DisplayName("여행기를 수정한다.")
     @Test
     void updateTravelogue() throws JsonProcessingException {
+        Mockito.when(s3Provider.copyImageToPermanentStorage(any(String.class)))
+                .thenReturn(TravelogueResponseFixture.getUpdatedTravelogueResponse().thumbnail());
+
         Travelogue travelogue = testHelper.initTravelogueTestData(member);
 
         List<TravelogueDayRequest> days = getUpdateTravelogueDayRequests();

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -2,6 +2,7 @@ package kr.touroot.travelogue.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -30,6 +31,7 @@ import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -204,6 +206,9 @@ class TravelogueFacadeServiceTest {
     @DisplayName("여행기를 수정할 수 있다.")
     @Test
     void updateTravelogue() {
+        Mockito.when(s3Provider.copyImageToPermanentStorage(any(String.class)))
+                .thenReturn(TravelogueResponseFixture.getUpdatedTravelogueResponse().thumbnail());
+
         List<TravelogueDayRequest> days = getUpdateTravelogueDayRequests();
         saveImages(days);
 


### PR DESCRIPTION
# ✅ 작업 내용
- 여행기 수정 시 썸네일을 임시 저장소에서 영구 저장소로 복사하도록 수정

# 🙈 참고 사항
