### PR TITLE
[Refactor] - 여행 계획 Service 코드 리팩터링

### DIFF
--- a/backend/src/main/java/kr/touroot/member/service/MyPageFacadeService.java
+++ b/backend/src/main/java/kr/touroot/member/service/MyPageFacadeService.java
@@ -43,7 +43,7 @@ public class MyPageFacadeService {
         Member member = memberService.getById(memberAuth.memberId());
         Page<TravelPlan> travelPlans = travelPlanService.getAllByAuthor(member, pageable);
 
-        return travelPlans.map((travelPlanService::getTravelPlanResponse));
+        return travelPlans.map(PlanResponse::from);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -112,7 +112,7 @@ public class TravelPlanController {
             @Valid MemberAuth memberAuth,
             @Valid @RequestBody PlanRequest request
     ) {
-        travelPlanFacadeService.updateTravelPlan(id, memberAuth, request);
+        travelPlanFacadeService.updateTravelPlanById(id, memberAuth, request);
         return ResponseEntity.ok().build();
     }
 
@@ -135,7 +135,7 @@ public class TravelPlanController {
     })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTravelPlan(@PathVariable Long id, MemberAuth memberAuth) {
-        travelPlanService.deleteByTravelPlanId(id, memberAuth);
+        travelPlanFacadeService.deleteTravelPlanById(id, memberAuth);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -156,7 +156,7 @@ public class TravelPlanController {
     public ResponseEntity<PlanResponse> readSharedTravelPlan(
             @Parameter(description = "여행 계획 공유 키") @PathVariable UUID shareKey
     ) {
-        PlanResponse data = travelPlanService.readTravelPlan(shareKey);
+        PlanResponse data = travelPlanFacadeService.findTravelPlanByShareKey(shareKey);
         return ResponseEntity.ok(data);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -112,7 +112,7 @@ public class TravelPlanController {
             @Valid MemberAuth memberAuth,
             @Valid @RequestBody PlanRequest request
     ) {
-        travelPlanService.updateTravelPlan(id, memberAuth, request);
+        travelPlanFacadeService.updateTravelPlan(id, memberAuth, request);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -15,6 +15,7 @@ import kr.touroot.global.exception.dto.ExceptionResponse;
 import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanResponse;
+import kr.touroot.travelplan.service.TravelPlanFacadeService;
 import kr.touroot.travelplan.service.TravelPlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/travel-plans")
 public class TravelPlanController {
 
+    private final TravelPlanFacadeService travelPlanFacadeService;
     private final TravelPlanService travelPlanService;
 
     @Operation(summary = "여행 계획 생성")
@@ -57,7 +59,7 @@ public class TravelPlanController {
             @Valid @RequestBody PlanRequest request,
             MemberAuth memberAuth
     ) {
-        PlanCreateResponse data = travelPlanService.createTravelPlan(request, memberAuth);
+        PlanCreateResponse data = travelPlanFacadeService.createTravelPlan(request, memberAuth);
         return ResponseEntity.created(URI.create("/api/v1/travel-plans/" + data.id())).build();
     }
 
@@ -83,7 +85,7 @@ public class TravelPlanController {
             @Parameter(description = "여행 계획 id") @PathVariable Long id,
             MemberAuth memberAuth
     ) {
-        PlanResponse data = travelPlanService.readTravelPlan(id, memberAuth);
+        PlanResponse data = travelPlanFacadeService.findTravelPlanById(id, memberAuth);
         return ResponseEntity.ok(data);
     }
 

--- a/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
+++ b/backend/src/main/java/kr/touroot/travelplan/controller/TravelPlanController.java
@@ -16,7 +16,6 @@ import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanResponse;
 import kr.touroot.travelplan.service.TravelPlanFacadeService;
-import kr.touroot.travelplan.service.TravelPlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,7 +34,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class TravelPlanController {
 
     private final TravelPlanFacadeService travelPlanFacadeService;
-    private final TravelPlanService travelPlanService;
 
     @Operation(summary = "여행 계획 생성")
     @ApiResponses(value = {

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlaceTodo.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlaceTodo.java
@@ -13,7 +13,6 @@ import kr.touroot.global.exception.BadRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -31,7 +30,6 @@ public class TravelPlaceTodo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private TravelPlanPlace travelPlanPlace;
@@ -94,5 +92,9 @@ public class TravelPlaceTodo extends BaseEntity {
 
     public void updateCheckedStatus(boolean checkedStatus) {
         isChecked = checkedStatus;
+    }
+
+    public void updateTravelPlanPlace(TravelPlanPlace travelPlanPlace) {
+        this.travelPlanPlace = travelPlanPlace;
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlaceTodo.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlaceTodo.java
@@ -13,6 +13,7 @@ import kr.touroot.global.exception.BadRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -30,6 +31,7 @@ public class TravelPlaceTodo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private TravelPlanPlace travelPlanPlace;

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
@@ -98,6 +98,11 @@ public class TravelPlan extends BaseEntity {
         this.startDate = startDate;
     }
 
+    public void updateDays(List<TravelPlanDay> travelPlanDays) {
+        this.travelPlanDays.clear();
+        travelPlanDays.forEach(this::addDay);
+    }
+
     public void addDay(TravelPlanDay day) {
         travelPlanDays.add(day);
         day.setPlan(this);

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
@@ -105,7 +105,7 @@ public class TravelPlan extends BaseEntity {
 
     public void addDay(TravelPlanDay day) {
         travelPlanDays.add(day);
-        day.setPlan(this);
+        day.updatePlan(this);
     }
 
     public boolean isStartDateBefore(LocalDate date) {

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlan.java
@@ -98,6 +98,11 @@ public class TravelPlan extends BaseEntity {
         this.startDate = startDate;
     }
 
+    public void addDay(TravelPlanDay day) {
+        travelPlanDays.add(day);
+        day.setPlan(this);
+    }
+
     public boolean isStartDateBefore(LocalDate date) {
         return startDate.isBefore(date);
     }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
@@ -18,7 +18,6 @@ import kr.touroot.global.exception.BadRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -34,9 +33,8 @@ public class TravelPlanDay extends BaseEntity {
     private Long id;
 
     @Column(name = "PLAN_DAY_ORDER", nullable = false)
-    Integer order;
+    private Integer order;
 
-    @Setter
     @JoinColumn(name = "PLAN_ID", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private TravelPlan plan;
@@ -74,11 +72,15 @@ public class TravelPlanDay extends BaseEntity {
 
     public void addPlace(TravelPlanPlace place) {
         travelPlanPlaces.add(place);
-        place.setDay(this);
+        place.updateDay(this);
     }
 
     public LocalDate getCurrentDate() {
         LocalDate startDate = plan.getStartDate();
         return startDate.plusDays(order);
+    }
+
+    public void updatePlan(TravelPlan plan) {
+        this.plan = plan;
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
@@ -72,6 +72,11 @@ public class TravelPlanDay extends BaseEntity {
         }
     }
 
+    public void addPlace(TravelPlanPlace place) {
+        travelPlanPlaces.add(place);
+        place.setDay(this);
+    }
+
     public LocalDate getCurrentDate() {
         LocalDate startDate = plan.getStartDate();
         return startDate.plusDays(order);

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanDay.java
@@ -18,6 +18,7 @@ import kr.touroot.global.exception.BadRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -35,6 +36,7 @@ public class TravelPlanDay extends BaseEntity {
     @Column(name = "PLAN_DAY_ORDER", nullable = false)
     Integer order;
 
+    @Setter
     @JoinColumn(name = "PLAN_ID", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private TravelPlan plan;

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
@@ -102,4 +102,9 @@ public class TravelPlanPlace extends BaseEntity {
             throw new BadRequestException("장소 이름은 " + PLACE_NAME_MAX_LENGTH + "자 이하여야 합니다");
         }
     }
+
+    public void addTodo(TravelPlaceTodo todo) {
+        travelPlaceTodos.add(todo);
+        todo.setTravelPlanPlace(this);
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
@@ -20,7 +20,6 @@ import kr.touroot.position.domain.Position;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -41,7 +40,6 @@ public class TravelPlanPlace extends BaseEntity {
     @Column(name = "PLAN_PLACE_ORDER", nullable = false)
     private Integer order;
 
-    @Setter
     @JoinColumn(name = "PLAN_DAY_ID", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private TravelPlanDay day;
@@ -105,6 +103,10 @@ public class TravelPlanPlace extends BaseEntity {
 
     public void addTodo(TravelPlaceTodo todo) {
         travelPlaceTodos.add(todo);
-        todo.setTravelPlanPlace(this);
+        todo.updateTravelPlanPlace(this);
+    }
+
+    public void updateDay(TravelPlanDay day) {
+        this.day = day;
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
+++ b/backend/src/main/java/kr/touroot/travelplan/domain/TravelPlanPlace.java
@@ -20,6 +20,7 @@ import kr.touroot.position.domain.Position;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -40,6 +41,7 @@ public class TravelPlanPlace extends BaseEntity {
     @Column(name = "PLAN_PLACE_ORDER", nullable = false)
     private Integer order;
 
+    @Setter
     @JoinColumn(name = "PLAN_DAY_ID", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private TravelPlanDay day;

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanDayRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanDayRequest.java
@@ -24,7 +24,7 @@ public record PlanDayRequest(
     }
 
     private void addPlaces(TravelPlanDay travelPlanDay) {
-        for (int order = 0; order < places().size(); order++) {
+        for (int order = 0; order < places.size(); order++) {
             PlanPlaceRequest planPlaceRequest = places.get(order);
             TravelPlanPlace planPlace = planPlaceRequest.toPlanPlace(order, travelPlanDay);
             travelPlanDay.addPlace(planPlace);

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanDayRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanDayRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.domain.TravelPlanDay;
+import kr.touroot.travelplan.domain.TravelPlanPlace;
 
 public record PlanDayRequest(
         @Schema(description = "여행 장소 정보")
@@ -17,6 +18,16 @@ public record PlanDayRequest(
 ) {
 
     public TravelPlanDay toPlanDay(int order, TravelPlan plan) {
-        return new TravelPlanDay(order, plan);
+        TravelPlanDay travelPlanDay = new TravelPlanDay(order, plan);
+        addPlaces(travelPlanDay);
+        return travelPlanDay;
+    }
+
+    private void addPlaces(TravelPlanDay travelPlanDay) {
+        for (int order = 0; order < places().size(); order++) {
+            PlanPlaceRequest planPlaceRequest = places.get(order);
+            TravelPlanPlace planPlace = planPlaceRequest.toPlanPlace(order, travelPlanDay);
+            travelPlanDay.addPlace(planPlace);
+        }
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanPlaceRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import kr.touroot.travelplan.domain.TravelPlaceTodo;
 import kr.touroot.travelplan.domain.TravelPlanDay;
 import kr.touroot.travelplan.domain.TravelPlanPlace;
 import lombok.Builder;
@@ -22,6 +23,22 @@ public record PlanPlaceRequest(
 ) {
 
     public TravelPlanPlace toPlanPlace(int order, TravelPlanDay day) {
-        return new TravelPlanPlace(order, day, placeName, position().lat(), position().lng());
+        TravelPlanPlace travelPlanPlace = new TravelPlanPlace(
+                order,
+                day,
+                placeName,
+                position().lat(),
+                position().lng()
+        );
+        addTodos(travelPlanPlace);
+        return travelPlanPlace;
+    }
+
+    private void addTodos(TravelPlanPlace travelPlanPlace) {
+        for (int order = 0; order < todos.size(); order++) {
+            PlanPlaceTodoRequest todoRequest = todos.get(order);
+            TravelPlaceTodo placeTodo = todoRequest.toPlaceTodo(travelPlanPlace, order);
+            travelPlanPlace.addTodo(placeTodo);
+        }
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import kr.touroot.member.domain.Member;
@@ -40,5 +41,16 @@ public record PlanRequest(
             TravelPlanDay planDay = planDayRequest.toPlanDay(order, travelPlan);
             travelPlan.addDay(planDay);
         }
+    }
+
+    public List<TravelPlanDay> getDays(TravelPlan travelPlan) {
+        List<TravelPlanDay> travelPlanDays = new ArrayList<>();
+        for (int order = 0; order < days.size(); order++) {
+            PlanDayRequest planDayRequest = days.get(order);
+            TravelPlanDay planDay = planDayRequest.toPlanDay(order, travelPlan);
+            travelPlanDays.add(planDay);
+        }
+
+        return travelPlanDays;
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanRequest.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/request/PlanRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.UUID;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelplan.domain.TravelPlan;
+import kr.touroot.travelplan.domain.TravelPlanDay;
 import lombok.Builder;
 
 @Builder
@@ -28,6 +29,16 @@ public record PlanRequest(
 ) {
 
     public TravelPlan toTravelPlan(Member author, UUID shareKey) {
-        return new TravelPlan(title, startDate, shareKey, author);
+        TravelPlan travelPlan = new TravelPlan(title, startDate, shareKey, author);
+        addDays(travelPlan);
+        return travelPlan;
+    }
+
+    private void addDays(TravelPlan travelPlan) {
+        for (int order = 0; order < days.size(); order++) {
+            PlanDayRequest planDayRequest = days.get(order);
+            TravelPlanDay planDay = planDayRequest.toPlanDay(order, travelPlan);
+            travelPlan.addDay(planDay);
+        }
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanCreateResponse.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanCreateResponse.java
@@ -1,9 +1,14 @@
 package kr.touroot.travelplan.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.touroot.travelplan.domain.TravelPlan;
 
 public record PlanCreateResponse(
         @Schema(description = "생성된 여행 계획 id", example = "1")
         Long id
 ) {
+
+    public static PlanCreateResponse from(TravelPlan travelPlan) {
+        return new PlanCreateResponse(travelPlan.getId());
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanDayResponse.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanDayResponse.java
@@ -13,14 +13,17 @@ public record PlanDayResponse(
         @Schema(description = "여행 장소별 정보") List<PlanPlaceResponse> places
 ) {
 
-    public static PlanDayResponse of(
-            TravelPlanDay planDay,
-            List<PlanPlaceResponse> places
-    ) {
+    public static PlanDayResponse from(TravelPlanDay planDay) {
         return PlanDayResponse.builder()
                 .id(planDay.getId())
                 .date(planDay.getCurrentDate())
-                .places(places)
+                .places(getTravelPlanPlaceResponse(planDay))
                 .build();
+    }
+
+    public static List<PlanPlaceResponse> getTravelPlanPlaceResponse(TravelPlanDay day) {
+        return day.getTravelPlanPlaces().stream()
+                .map(PlanPlaceResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanPlaceResponse.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanPlaceResponse.java
@@ -13,12 +13,18 @@ public record PlanPlaceResponse(
         @Schema(description = "여행 장소 TODO") List<PlanPlaceTodoResponse> todos
 ) {
 
-    public static PlanPlaceResponse of(TravelPlanPlace planPlace, List<PlanPlaceTodoResponse> todos) {
+    public static PlanPlaceResponse from(TravelPlanPlace planPlace) {
         return PlanPlaceResponse.builder()
                 .id(planPlace.getId())
                 .placeName(planPlace.getName())
                 .position(PlanPositionResponse.from(planPlace.getPosition()))
-                .todos(todos)
+                .todos(getTodoResponse(planPlace))
                 .build();
+    }
+
+    private static List<PlanPlaceTodoResponse> getTodoResponse(TravelPlanPlace planPlace) {
+        return planPlace.getTravelPlaceTodos().stream()
+                .map(PlanPlaceTodoResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanResponse.java
+++ b/backend/src/main/java/kr/touroot/travelplan/dto/response/PlanResponse.java
@@ -16,13 +16,19 @@ public record PlanResponse(
         @Schema(description = "여행 계획 공유 share Key") UUID shareKey
 ) {
 
-    public static PlanResponse of(TravelPlan travelPlan, List<PlanDayResponse> days) {
+    public static PlanResponse from(TravelPlan travelPlan) {
         return PlanResponse.builder()
                 .id(travelPlan.getId())
                 .title(travelPlan.getTitle())
                 .startDate(travelPlan.getStartDate())
-                .days(days)
+                .days(getTravelPlanDaysResponse(travelPlan))
                 .shareKey(travelPlan.getShareKey())
                 .build();
+    }
+
+    private static List<PlanDayResponse> getTravelPlanDaysResponse(TravelPlan travelPlan) {
+        return travelPlan.getTravelPlanDays().stream()
+                .map(PlanDayResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/repository/PlaceTodoRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/PlaceTodoRepository.java
@@ -1,14 +1,7 @@
 package kr.touroot.travelplan.repository;
 
-import java.util.List;
 import kr.touroot.travelplan.domain.TravelPlaceTodo;
-import kr.touroot.travelplan.domain.TravelPlan;
-import kr.touroot.travelplan.domain.TravelPlanPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceTodoRepository extends JpaRepository<TravelPlaceTodo, Long> {
-
-    List<TravelPlaceTodo> findByTravelPlanPlace(TravelPlanPlace travelPlanPlace);
-
-    void deleteByTravelPlanPlaceDayPlan(TravelPlan travelPlan);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanDayRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanDayRepository.java
@@ -1,13 +1,7 @@
 package kr.touroot.travelplan.repository;
 
-import java.util.List;
-import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.domain.TravelPlanDay;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelPlanDayRepository extends JpaRepository<TravelPlanDay, Long> {
-
-    List<TravelPlanDay> findByPlan(TravelPlan travelPlan);
-
-    void deleteByPlan(TravelPlan plan);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanPlaceRepository.java
+++ b/backend/src/main/java/kr/touroot/travelplan/repository/TravelPlanPlaceRepository.java
@@ -1,14 +1,7 @@
 package kr.touroot.travelplan.repository;
 
-import java.util.List;
-import kr.touroot.travelplan.domain.TravelPlan;
-import kr.touroot.travelplan.domain.TravelPlanDay;
 import kr.touroot.travelplan.domain.TravelPlanPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelPlanPlaceRepository extends JpaRepository<TravelPlanPlace, Long> {
-
-    List<TravelPlanPlace> findByDay(TravelPlanDay day);
-
-    void deleteByDayPlan(TravelPlan plan);
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -24,7 +24,7 @@ public class TravelPlanFacadeService {
     public PlanCreateResponse createTravelPlan(PlanRequest request, MemberAuth memberAuth) {
         Member author = memberService.getById(memberAuth.memberId());
         TravelPlan travelPlan = request.toTravelPlan(author, UUID.randomUUID());
-        TravelPlan savedTravelPlan = travelPlanService.save(travelPlan, author);
+        TravelPlan savedTravelPlan = travelPlanService.save(travelPlan);
 
         return PlanCreateResponse.from(savedTravelPlan);
     }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -1,0 +1,41 @@
+package kr.touroot.travelplan.service;
+
+import java.util.UUID;
+import kr.touroot.global.auth.dto.MemberAuth;
+import kr.touroot.member.domain.Member;
+import kr.touroot.member.service.MemberService;
+import kr.touroot.travelplan.domain.TravelPlan;
+import kr.touroot.travelplan.dto.request.PlanRequest;
+import kr.touroot.travelplan.dto.response.PlanCreateResponse;
+import kr.touroot.travelplan.dto.response.PlanResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// TODO: 테스트 작성
+@RequiredArgsConstructor
+@Service
+public class TravelPlanFacadeService {
+
+    private final MemberService memberService;
+    private final TravelPlanService travelPlanService;
+
+    @Transactional
+    public PlanCreateResponse createTravelPlan(PlanRequest request, MemberAuth memberAuth) {
+        Member author = memberService.getById(memberAuth.memberId());
+        TravelPlan travelPlan = request.toTravelPlan(author, UUID.randomUUID());
+        TravelPlan savedTravelPlan = travelPlanService.save(travelPlan, author);
+
+        return PlanCreateResponse.from(savedTravelPlan);
+    }
+
+    @Transactional(readOnly = true)
+    public PlanResponse findTravelPlanById(Long planId, MemberAuth memberAuth) {
+        Member accessor = memberService.getById(memberAuth.memberId());
+        TravelPlan travelPlan = travelPlanService.getTravelPlanById(planId, accessor);
+
+        return PlanResponse.from(travelPlan);
+    }
+
+
+}

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -38,10 +38,18 @@ public class TravelPlanFacadeService {
     }
 
     @Transactional
-    public void updateTravelPlan(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
+    public void updateTravelPlanById(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
         TravelPlan travelPlan = travelPlanService.getTravelPlanById(id);
         Member accessor = memberService.getById(memberAuth.memberId());
 
         travelPlanService.updateTravelPlan(travelPlan, accessor, planUpdateRequest);
+    }
+
+    @Transactional
+    public void deleteTravelPlanById(Long id, MemberAuth memberAuth) {
+        TravelPlan travelPlan = travelPlanService.getTravelPlanById(id);
+        Member accessor = memberService.getById(memberAuth.memberId());
+
+        travelPlanService.deleteTravelPlan(travelPlan, accessor);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -42,11 +42,12 @@ public class TravelPlanFacadeService {
     }
 
     @Transactional
-    public void updateTravelPlanById(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
+    public PlanResponse updateTravelPlanById(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
         Member accessor = memberService.getById(memberAuth.memberId());
         TravelPlan travelPlan = travelPlanService.getTravelPlanById(id, accessor);
-
-        travelPlanService.updateTravelPlan(travelPlan, accessor, planUpdateRequest);
+        TravelPlan updated = travelPlanService.updateTravelPlan(travelPlan, accessor, planUpdateRequest);
+        
+        return PlanResponse.from(updated);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// TODO: 테스트 작성
 @RequiredArgsConstructor
 @Service
 public class TravelPlanFacadeService {
@@ -39,21 +38,21 @@ public class TravelPlanFacadeService {
 
     @Transactional(readOnly = true)
     public PlanResponse findTravelPlanByShareKey(UUID shareKey) {
-        return travelPlanService.readTravelPlan(shareKey);
+        return PlanResponse.from(travelPlanService.getTravelPlanByShareKey(shareKey));
     }
 
     @Transactional
     public void updateTravelPlanById(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
-        TravelPlan travelPlan = travelPlanService.getTravelPlanById(id);
         Member accessor = memberService.getById(memberAuth.memberId());
+        TravelPlan travelPlan = travelPlanService.getTravelPlanById(id, accessor);
 
         travelPlanService.updateTravelPlan(travelPlan, accessor, planUpdateRequest);
     }
 
     @Transactional
     public void deleteTravelPlanById(Long id, MemberAuth memberAuth) {
-        TravelPlan travelPlan = travelPlanService.getTravelPlanById(id);
         Member accessor = memberService.getById(memberAuth.memberId());
+        TravelPlan travelPlan = travelPlanService.getTravelPlanById(id, accessor);
 
         travelPlanService.deleteTravelPlan(travelPlan, accessor);
     }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -37,5 +37,11 @@ public class TravelPlanFacadeService {
         return PlanResponse.from(travelPlan);
     }
 
+    @Transactional
+    public void updateTravelPlan(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
+        TravelPlan travelPlan = travelPlanService.getTravelPlanById(id);
+        Member accessor = memberService.getById(memberAuth.memberId());
 
+        travelPlanService.updateTravelPlan(travelPlan, accessor, planUpdateRequest);
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanFacadeService.java
@@ -37,6 +37,11 @@ public class TravelPlanFacadeService {
         return PlanResponse.from(travelPlan);
     }
 
+    @Transactional(readOnly = true)
+    public PlanResponse findTravelPlanByShareKey(UUID shareKey) {
+        return travelPlanService.readTravelPlan(shareKey);
+    }
+
     @Transactional
     public void updateTravelPlanById(Long id, MemberAuth memberAuth, PlanRequest planUpdateRequest) {
         TravelPlan travelPlan = travelPlanService.getTravelPlanById(id);

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -85,19 +85,9 @@ public class TravelPlanService {
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));
     }
 
-    public PlanResponse getTravelPlanResponse(TravelPlan travelPlan) {
-        return PlanResponse.from(travelPlan);
-    }
-
     @Transactional(readOnly = true)
     public Page<TravelPlan> getAllByAuthor(Member member, Pageable pageable) {
         return travelPlanRepository.findAllByAuthor(member, pageable);
-    }
-
-    @Transactional(readOnly = true)
-    public int calculateTravelPeriod(TravelPlan travelPlan) {
-        return travelPlanDayRepository.findByPlan(travelPlan)
-                .size();
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -1,23 +1,15 @@
 package kr.touroot.travelplan.service;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
 import java.util.UUID;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.member.domain.Member;
 import kr.touroot.member.repository.MemberRepository;
-import kr.touroot.travelplan.domain.TravelPlaceTodo;
 import kr.touroot.travelplan.domain.TravelPlan;
-import kr.touroot.travelplan.domain.TravelPlanDay;
-import kr.touroot.travelplan.domain.TravelPlanPlace;
 import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
-import kr.touroot.travelplan.dto.response.PlanDayResponse;
-import kr.touroot.travelplan.dto.response.PlanPlaceResponse;
-import kr.touroot.travelplan.dto.response.PlanPlaceTodoResponse;
 import kr.touroot.travelplan.dto.response.PlanResponse;
 import kr.touroot.travelplan.repository.PlaceTodoRepository;
 import kr.touroot.travelplan.repository.TravelPlanDayRepository;
@@ -67,7 +59,7 @@ public class TravelPlanService {
         Member member = getMemberByMemberAuth(memberAuth);
         validateReadByAuthor(travelPlan, member);
 
-        return PlanResponse.of(travelPlan, getTravelPlanDayResponses(travelPlan));
+        return PlanResponse.from(travelPlan);
     }
 
     private void validateReadByAuthor(TravelPlan travelPlan, Member member) {
@@ -80,7 +72,7 @@ public class TravelPlanService {
     public PlanResponse readTravelPlan(UUID shareKey) {
         TravelPlan travelPlan = getTravelPlanByShareKey(shareKey);
 
-        return PlanResponse.of(travelPlan, getTravelPlanDayResponses(travelPlan));
+        return PlanResponse.from(travelPlan);
     }
 
     private TravelPlan getTravelPlanById(Long planId) {
@@ -94,33 +86,7 @@ public class TravelPlanService {
     }
 
     public PlanResponse getTravelPlanResponse(TravelPlan travelPlan) {
-        return PlanResponse.of(travelPlan, getTravelPlanDayResponses(travelPlan));
-    }
-
-    private List<PlanDayResponse> getTravelPlanDayResponses(TravelPlan travelPlan) {
-        List<TravelPlanDay> planDays = travelPlanDayRepository.findByPlan(travelPlan);
-
-        return planDays.stream()
-                .sorted(Comparator.comparing(TravelPlanDay::getOrder))
-                .map(day -> PlanDayResponse.of(day, getTravelPlanPlaceResponses(day)))
-                .toList();
-    }
-
-    private List<PlanPlaceResponse> getTravelPlanPlaceResponses(TravelPlanDay day) {
-        List<TravelPlanPlace> places = travelPlanPlaceRepository.findByDay(day);
-
-        return places.stream()
-                .sorted(Comparator.comparing(TravelPlanPlace::getOrder))
-                .map(place -> PlanPlaceResponse.of(place, getPlaceTodos(place)))
-                .toList();
-    }
-
-    private List<PlanPlaceTodoResponse> getPlaceTodos(TravelPlanPlace place) {
-        return placeTodoRepository.findByTravelPlanPlace(place)
-                .stream()
-                .sorted(Comparator.comparing(TravelPlaceTodo::getOrder))
-                .map(PlanPlaceTodoResponse::from)
-                .toList();
+        return PlanResponse.from(travelPlan);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -2,18 +2,12 @@ package kr.touroot.travelplan.service;
 
 import java.time.LocalDate;
 import java.util.UUID;
-import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.member.domain.Member;
 import kr.touroot.member.repository.MemberRepository;
 import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.dto.request.PlanRequest;
-import kr.touroot.travelplan.dto.response.PlanCreateResponse;
-import kr.touroot.travelplan.dto.response.PlanResponse;
-import kr.touroot.travelplan.repository.PlaceTodoRepository;
-import kr.touroot.travelplan.repository.TravelPlanDayRepository;
-import kr.touroot.travelplan.repository.TravelPlanPlaceRepository;
 import kr.touroot.travelplan.repository.TravelPlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,20 +21,6 @@ public class TravelPlanService {
 
     private final MemberRepository memberRepository;
     private final TravelPlanRepository travelPlanRepository;
-    private final TravelPlanDayRepository travelPlanDayRepository;
-    private final TravelPlanPlaceRepository travelPlanPlaceRepository;
-    private final PlaceTodoRepository placeTodoRepository;
-
-    @Transactional
-    public PlanCreateResponse createTravelPlan(PlanRequest request, MemberAuth memberAuth) {
-        Member author = getMemberByMemberAuth(memberAuth);
-        TravelPlan travelPlan = request.toTravelPlan(author, UUID.randomUUID());
-        validateTravelPlanStartDate(travelPlan);
-
-        TravelPlan savedTravelPlan = travelPlanRepository.save(travelPlan);
-
-        return PlanCreateResponse.from(savedTravelPlan);
-    }
 
     @Transactional
     public TravelPlan save(TravelPlan travelPlan) {
@@ -54,47 +34,22 @@ public class TravelPlanService {
         }
     }
 
-    private Member getMemberByMemberAuth(MemberAuth memberAuth) {
-        return memberRepository.findById(memberAuth.memberId())
-                .orElseThrow(() -> new BadRequestException("존재하지 않는 사용자입니다."));
-    }
-
     @Transactional(readOnly = true)
-    public PlanResponse readTravelPlan(Long planId, MemberAuth memberAuth) {
-        TravelPlan travelPlan = getTravelPlanById(planId);
-        Member member = getMemberByMemberAuth(memberAuth);
-        validateReadByAuthor(travelPlan, member);
-
-        return PlanResponse.from(travelPlan);
-    }
-
-    private void validateReadByAuthor(TravelPlan travelPlan, Member member) {
-        if (!travelPlan.isAuthor(member)) {
-            throw new ForbiddenException("여행 계획 조회는 작성자만 가능합니다.");
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public PlanResponse readTravelPlan(UUID shareKey) {
-        TravelPlan travelPlan = getTravelPlanByShareKey(shareKey);
-
-        return PlanResponse.from(travelPlan);
-    }
-
-    public TravelPlan getTravelPlanById(Long planId) {
-        return travelPlanRepository.findById(planId)
-                .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));
-    }
-
     public TravelPlan getTravelPlanById(Long planId, Member accessor) {
         TravelPlan travelPlan = travelPlanRepository.findById(planId)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));
-        validateReadByAuthor(travelPlan, accessor);
+        validateAccessFromAuthor(travelPlan, accessor);
 
         return travelPlan;
     }
 
-    private TravelPlan getTravelPlanByShareKey(UUID shareKey) {
+    private void validateAccessFromAuthor(TravelPlan travelPlan, Member member) {
+        if (!travelPlan.isAuthor(member)) {
+            throw new ForbiddenException("여행 계획은 작성자만 접근 가능합니다.");
+        }
+    }
+
+    public TravelPlan getTravelPlanByShareKey(UUID shareKey) {
         return travelPlanRepository.findByShareKey(shareKey)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));
     }
@@ -104,71 +59,18 @@ public class TravelPlanService {
         return travelPlanRepository.findAllByAuthor(member, pageable);
     }
 
-    @Transactional
-    public PlanCreateResponse updateTravelPlan(Long planId, MemberAuth memberAuth, PlanRequest request) {
-        TravelPlan travelPlan = getTravelPlanById(planId);
-        Member author = getMemberByMemberAuth(memberAuth);
-        validateUpdateByAuthor(travelPlan, author);
-
-        clearTravelPlanContents(travelPlan);
-
-        updateTravelPlanContents(request, travelPlan);
-        return new PlanCreateResponse(travelPlan.getId());
-    }
 
     @Transactional
     public void updateTravelPlan(TravelPlan travelPlan, Member member, PlanRequest updateRequest) {
-        validateUpdateByAuthor(travelPlan, member);
+        validateAccessFromAuthor(travelPlan, member);
         travelPlan.updateDays(updateRequest.getDays(travelPlan));
         travelPlan.update(updateRequest.title(), updateRequest.startDate());
         travelPlanRepository.save(travelPlan);
     }
 
     @Transactional
-    public void updateTravelPlanTitleAndStartDate(TravelPlan travelPlan, String title, LocalDate startDate) {
-        travelPlan.update(title, startDate);
-    }
-
-    private void validateUpdateByAuthor(TravelPlan travelPlan, Member member) {
-        if (!travelPlan.isAuthor(member)) {
-            throw new ForbiddenException("여행 계획 수정은 작성자만 가능합니다.");
-        }
-    }
-
-    private void clearTravelPlanContents(TravelPlan travelPlan) {
-        placeTodoRepository.deleteByTravelPlanPlaceDayPlan(travelPlan);
-        travelPlanPlaceRepository.deleteByDayPlan(travelPlan);
-        travelPlanDayRepository.deleteByPlan(travelPlan);
-    }
-
-    private void updateTravelPlanContents(PlanRequest request, TravelPlan travelPlan) {
-        travelPlan.update(request.title(), request.startDate());
-        travelPlan.updateDays(request.getDays(travelPlan));
-        travelPlanRepository.save(travelPlan);
-    }
-
-    @Transactional
-    public void deleteByTravelPlanId(Long planId, MemberAuth memberAuth) {
-        TravelPlan travelPlan = getTravelPlanById(planId);
-        Member author = getMemberByMemberAuth(memberAuth);
-        validateDeleteByAuthor(travelPlan, author);
-
-        placeTodoRepository.deleteByTravelPlanPlaceDayPlan(travelPlan);
-        travelPlanPlaceRepository.deleteByDayPlan(travelPlan);
-        travelPlanDayRepository.deleteByPlan(travelPlan);
-        travelPlanRepository.delete(travelPlan);
-    }
-
-    @Transactional
     public void deleteTravelPlan(TravelPlan travelPlan, Member author) {
-        validateDeleteByAuthor(travelPlan, author);
+        validateAccessFromAuthor(travelPlan, author);
         travelPlanRepository.delete(travelPlan);
     }
-
-    private void validateDeleteByAuthor(TravelPlan travelPlan, Member member) {
-        if (!travelPlan.isAuthor(member)) {
-            throw new ForbiddenException("여행 계획 삭제는 작성자만 가능합니다.");
-        }
-    }
-
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -42,6 +42,12 @@ public class TravelPlanService {
         return PlanCreateResponse.from(savedTravelPlan);
     }
 
+    @Transactional
+    public TravelPlan save(TravelPlan travelPlan, Member author) {
+        validateTravelPlanStartDate(travelPlan);
+        return travelPlanRepository.save(travelPlan);
+    }
+
     private void validateTravelPlanStartDate(TravelPlan travelPlan) {
         if (travelPlan.isStartDateBefore(LocalDate.now())) {
             throw new BadRequestException("지난 날짜에 대한 계획은 작성할 수 없습니다.");
@@ -75,9 +81,17 @@ public class TravelPlanService {
         return PlanResponse.from(travelPlan);
     }
 
-    private TravelPlan getTravelPlanById(Long planId) {
+    public TravelPlan getTravelPlanById(Long planId) {
         return travelPlanRepository.findById(planId)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));
+    }
+
+    public TravelPlan getTravelPlanById(Long planId, Member accessor) {
+        TravelPlan travelPlan = travelPlanRepository.findById(planId)
+                .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));
+        validateReadByAuthor(travelPlan, accessor);
+
+        return travelPlan;
     }
 
     private TravelPlan getTravelPlanByShareKey(UUID shareKey) {

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.member.domain.Member;
-import kr.touroot.member.repository.MemberRepository;
 import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.repository.TravelPlanRepository;
@@ -19,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TravelPlanService {
 
-    private final MemberRepository memberRepository;
     private final TravelPlanRepository travelPlanRepository;
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -43,7 +43,7 @@ public class TravelPlanService {
     }
 
     @Transactional
-    public TravelPlan save(TravelPlan travelPlan, Member author) {
+    public TravelPlan save(TravelPlan travelPlan) {
         validateTravelPlanStartDate(travelPlan);
         return travelPlanRepository.save(travelPlan);
     }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -13,9 +13,6 @@ import kr.touroot.travelplan.domain.TravelPlaceTodo;
 import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.domain.TravelPlanDay;
 import kr.touroot.travelplan.domain.TravelPlanPlace;
-import kr.touroot.travelplan.dto.request.PlanDayRequest;
-import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
-import kr.touroot.travelplan.dto.request.PlanPlaceTodoRequest;
 import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanDayResponse;
@@ -62,31 +59,6 @@ public class TravelPlanService {
     private Member getMemberByMemberAuth(MemberAuth memberAuth) {
         return memberRepository.findById(memberAuth.memberId())
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 사용자입니다."));
-    }
-
-    private void createPlanDay(List<PlanDayRequest> request, TravelPlan savedTravelPlan) {
-        for (int order = 0; order < request.size(); order++) {
-            PlanDayRequest dayRequest = request.get(order);
-            TravelPlanDay travelPlanDay = travelPlanDayRepository.save(dayRequest.toPlanDay(order, savedTravelPlan));
-            createPlanPlace(dayRequest.places(), travelPlanDay);
-        }
-    }
-
-    private void createPlanPlace(List<PlanPlaceRequest> request, TravelPlanDay travelPlanDay) {
-        for (int order = 0; order < request.size(); order++) {
-            PlanPlaceRequest planRequest = request.get(order);
-            TravelPlanPlace planPlace = planRequest.toPlanPlace(order, travelPlanDay);
-            TravelPlanPlace travelPlanPlace = travelPlanPlaceRepository.save(planPlace);
-            createPlaceTodo(planRequest.todos(), travelPlanPlace);
-        }
-    }
-
-    private void createPlaceTodo(List<PlanPlaceTodoRequest> request, TravelPlanPlace travelPlanPlace) {
-        for (int order = 0; order < request.size(); order++) {
-            PlanPlaceTodoRequest todoRequest = request.get(order);
-            TravelPlaceTodo travelPlaceTodo = todoRequest.toPlaceTodo(travelPlanPlace, order);
-            placeTodoRepository.save(travelPlaceTodo);
-        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -169,6 +169,7 @@ public class TravelPlanService {
         validateUpdateByAuthor(travelPlan, author);
 
         clearTravelPlanContents(travelPlan);
+
         updateTravelPlanContents(request, travelPlan);
         return new PlanCreateResponse(travelPlan.getId());
     }
@@ -187,8 +188,8 @@ public class TravelPlanService {
 
     private void updateTravelPlanContents(PlanRequest request, TravelPlan travelPlan) {
         travelPlan.update(request.title(), request.startDate());
+        travelPlan.updateDays(request.getDays(travelPlan));
         travelPlanRepository.save(travelPlan);
-        createPlanDay(request.days(), travelPlan);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -61,11 +61,11 @@ public class TravelPlanService {
 
 
     @Transactional
-    public void updateTravelPlan(TravelPlan travelPlan, Member member, PlanRequest updateRequest) {
+    public TravelPlan updateTravelPlan(TravelPlan travelPlan, Member member, PlanRequest updateRequest) {
         validateAccessFromAuthor(travelPlan, member);
         travelPlan.updateDays(updateRequest.getDays(travelPlan));
         travelPlan.update(updateRequest.title(), updateRequest.startDate());
-        travelPlanRepository.save(travelPlan);
+        return travelPlanRepository.save(travelPlan);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -116,6 +116,19 @@ public class TravelPlanService {
         return new PlanCreateResponse(travelPlan.getId());
     }
 
+    @Transactional
+    public void updateTravelPlan(TravelPlan travelPlan, Member member, PlanRequest updateRequest) {
+        validateUpdateByAuthor(travelPlan, member);
+        travelPlan.updateDays(updateRequest.getDays(travelPlan));
+        travelPlan.update(updateRequest.title(), updateRequest.startDate());
+        travelPlanRepository.save(travelPlan);
+    }
+
+    @Transactional
+    public void updateTravelPlanTitleAndStartDate(TravelPlan travelPlan, String title, LocalDate startDate) {
+        travelPlan.update(title, startDate);
+    }
+
     private void validateUpdateByAuthor(TravelPlan travelPlan, Member member) {
         if (!travelPlan.isAuthor(member)) {
             throw new ForbiddenException("여행 계획 수정은 작성자만 가능합니다.");

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -50,7 +50,7 @@ public class TravelPlanService {
 
         TravelPlan savedTravelPlan = travelPlanRepository.save(travelPlan);
 
-        return new PlanCreateResponse(savedTravelPlan.getId());
+        return PlanCreateResponse.from(savedTravelPlan);
     }
 
     private void validateTravelPlanStartDate(TravelPlan travelPlan) {

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -46,15 +46,14 @@ public class TravelPlanService {
     public PlanCreateResponse createTravelPlan(PlanRequest request, MemberAuth memberAuth) {
         Member author = getMemberByMemberAuth(memberAuth);
         TravelPlan travelPlan = request.toTravelPlan(author, UUID.randomUUID());
-        validateCreateTravelPlan(travelPlan);
+        validateTravelPlanStartDate(travelPlan);
 
         TravelPlan savedTravelPlan = travelPlanRepository.save(travelPlan);
-        createPlanDay(request.days(), savedTravelPlan);
 
         return new PlanCreateResponse(savedTravelPlan.getId());
     }
 
-    private void validateCreateTravelPlan(TravelPlan travelPlan) {
+    private void validateTravelPlanStartDate(TravelPlan travelPlan) {
         if (travelPlan.isStartDateBefore(LocalDate.now())) {
             throw new BadRequestException("지난 날짜에 대한 계획은 작성할 수 없습니다.");
         }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -159,9 +159,16 @@ public class TravelPlanService {
         travelPlanRepository.delete(travelPlan);
     }
 
+    @Transactional
+    public void deleteTravelPlan(TravelPlan travelPlan, Member author) {
+        validateDeleteByAuthor(travelPlan, author);
+        travelPlanRepository.delete(travelPlan);
+    }
+
     private void validateDeleteByAuthor(TravelPlan travelPlan, Member member) {
         if (!travelPlan.isAuthor(member)) {
             throw new ForbiddenException("여행 계획 삭제는 작성자만 가능합니다.");
         }
     }
+
 }

--- a/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
+++ b/backend/src/main/java/kr/touroot/travelplan/service/TravelPlanService.java
@@ -49,6 +49,7 @@ public class TravelPlanService {
         }
     }
 
+    @Transactional(readOnly = true)
     public TravelPlan getTravelPlanByShareKey(UUID shareKey) {
         return travelPlanRepository.findByShareKey(shareKey)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 여행 계획입니다."));

--- a/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/controller/TravelPlanControllerTest.java
@@ -172,7 +172,7 @@ class TravelPlanControllerTest {
                 .get("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("여행 계획 조회는 작성자만 가능합니다."));
+                .body("message", is("여행 계획은 작성자만 접근 가능합니다."));
     }
 
     @DisplayName("여행 계획 공유 키를 통해 여행 계획을 조회할 수 있다")
@@ -333,7 +333,7 @@ class TravelPlanControllerTest {
                 .when().put("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("여행 계획 수정은 작성자만 가능합니다."));
+                .body("message", is("여행 계획은 작성자만 접근 가능합니다."));
     }
 
     @DisplayName("여행계획을 삭제한다.")
@@ -373,6 +373,6 @@ class TravelPlanControllerTest {
                 .when().delete("/api/v1/travel-plans/" + id)
                 .then().log().all()
                 .statusCode(403)
-                .body("message", is("여행 계획 삭제는 작성자만 가능합니다."));
+                .body("message", is("여행 계획은 작성자만 접근 가능합니다."));
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/domain/TravelPlanDayTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/domain/TravelPlanDayTest.java
@@ -1,10 +1,13 @@
 package kr.touroot.travelplan.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import kr.touroot.global.exception.BadRequestException;
+import kr.touroot.travelplan.fixture.TravelPlanDayFixture;
 import kr.touroot.travelplan.fixture.TravelPlanFixture;
+import kr.touroot.travelplan.fixture.TravelPlanPlaceFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,5 +49,27 @@ class TravelPlanDayTest {
         assertThatThrownBy(() -> new TravelPlanDay(negative, VALID_PLAN))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("여행 계획 날짜 순서는 음수일 수 없습니다");
+    }
+
+    @DisplayName("여행 계획 장소를 추가할 수 있다")
+    @Test
+    void addTravelPlanPlaceInTravelPlanDay() {
+        TravelPlanDay travelPlanDay = TravelPlanDayFixture.TRAVEL_PLAN_DAY.get();
+        TravelPlanPlace travelPlanPlace = TravelPlanPlaceFixture.TRAVEL_PLAN_PLACE.get();
+
+        travelPlanDay.addPlace(travelPlanPlace);
+
+        assertThat(travelPlanDay.getTravelPlanPlaces()).containsExactly(travelPlanPlace);
+    }
+
+    @DisplayName("여행 계획 날짜에 장소를 추가하는 경우 장소의 날짜 참조도 수정된다")
+    @Test
+    void addTravelPlanPlaceThenTravelPlanDayUpdated() {
+        TravelPlanDay travelPlanDay = TravelPlanDayFixture.TRAVEL_PLAN_DAY.get();
+        TravelPlanPlace travelPlanPlace = TravelPlanPlaceFixture.TRAVEL_PLAN_PLACE.get();
+
+        travelPlanDay.addPlace(travelPlanPlace);
+
+        assertThat(travelPlanPlace.getDay()).isEqualTo(travelPlanDay);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/domain/TravelPlanPlaceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/domain/TravelPlanPlaceTest.java
@@ -1,10 +1,12 @@
 package kr.touroot.travelplan.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.travelplan.fixture.TravelPlanDayFixture;
+import kr.touroot.travelplan.fixture.TravelPlanPlaceFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,5 +77,27 @@ class TravelPlanPlaceTest {
         assertThatThrownBy(() -> new TravelPlanPlace(VALID_ORDER, VALID_DAY, length61, VALID_LAT, VALID_LNG))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("장소 이름은 60자 이하여야 합니다");
+    }
+
+    @DisplayName("Todo를 추가할 수 있다")
+    @Test
+    void addTodoInPlace() {
+        TravelPlanPlace travelPlanPlace = TravelPlanPlaceFixture.TRAVEL_PLAN_PLACE.get();
+        TravelPlaceTodo travelPlaceTodo = new TravelPlaceTodo(travelPlanPlace, "투룻 하기", 1, true);
+
+        travelPlanPlace.addTodo(travelPlaceTodo);
+
+        assertThat(travelPlanPlace.getTravelPlaceTodos()).containsExactly(travelPlaceTodo);
+    }
+
+    @DisplayName("장소에 Todo를 추가하면 Todo의 장소 참조도 수정된다")
+    @Test
+    void addTodoThenTodosPlaceUpdated() {
+        TravelPlanPlace travelPlanPlace = TravelPlanPlaceFixture.TRAVEL_PLAN_PLACE.get();
+        TravelPlaceTodo travelPlaceTodo = new TravelPlaceTodo(travelPlanPlace, "투룻 하기", 1, true);
+
+        travelPlanPlace.addTodo(travelPlaceTodo);
+
+        assertThat(travelPlaceTodo.getTravelPlanPlace()).isEqualTo(travelPlanPlace);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/domain/TravelPlanTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/domain/TravelPlanTest.java
@@ -6,11 +6,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.member.domain.LoginType;
 import kr.touroot.member.domain.Member;
 import kr.touroot.member.fixture.MemberFixture;
+import kr.touroot.travelplan.fixture.TravelPlanDayFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -106,5 +108,47 @@ class TravelPlanTest {
 
         // then
         assertThat(actual).isFalse();
+    }
+
+    @DisplayName("여행 계획 날짜를 추가할 수 있다")
+    @Test
+    void addDayInTravelPlan() {
+        // given
+        TravelPlan travelPlan = new TravelPlan(VALID_TITLE, VALID_START_DATE, VALID_UUID, VALID_AUTHOR);
+        TravelPlanDay travelPlanDay = TravelPlanDayFixture.TRAVEL_PLAN_DAY.get();
+
+        // when
+        travelPlan.addDay(travelPlanDay);
+
+        // then
+        assertThat(travelPlan.getTravelPlanDays()).containsExactly(travelPlanDay);
+    }
+
+    @DisplayName("여행 계획에 여행 계획 날짜를 추가하면 계획 날짜의 여행 계획 참조도 수정된다")
+    @Test
+    void addDayThenDaysPlanUpdated() {
+        // given
+        TravelPlan travelPlan = new TravelPlan(VALID_TITLE, VALID_START_DATE, VALID_UUID, VALID_AUTHOR);
+        TravelPlanDay travelPlanDay = TravelPlanDayFixture.TRAVEL_PLAN_DAY.get();
+
+        // when
+        travelPlan.addDay(travelPlanDay);
+
+        // then
+        assertThat(travelPlanDay.getPlan()).isEqualTo(travelPlan);
+    }
+
+    @DisplayName("여행 계획의 날짜들을 새로운 날짜들로 업데이트 할 수 있다")
+    @Test
+    void updateDaysInTravelPlan() {
+        // given
+        TravelPlan travelPlan = new TravelPlan(VALID_TITLE, VALID_START_DATE, VALID_UUID, VALID_AUTHOR);
+        TravelPlanDay travelPlanDay = TravelPlanDayFixture.TRAVEL_PLAN_DAY.get();
+
+        // when
+        travelPlan.updateDays(List.of(travelPlanDay));
+
+        // then
+        assertThat(travelPlan.getTravelPlanDays()).containsExactly(travelPlanDay);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/fixture/TravelPlanFixture.java
+++ b/backend/src/test/java/kr/touroot/travelplan/fixture/TravelPlanFixture.java
@@ -11,13 +11,22 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum TravelPlanFixture {
 
-    TRAVEL_PLAN("제주도 여행 계획", LocalDate.now().plusDays(2), MemberFixture.KAKAO_MEMBER.build());
+    TRAVEL_PLAN("제주도 여행 계획", LocalDate.now().plusDays(2), UUID.randomUUID(), MemberFixture.KAKAO_MEMBER.build());
 
     private final String title;
     private final LocalDate startDate;
+    private final UUID shareKey;
     private final Member author;
 
     public TravelPlan get() {
-        return new TravelPlan(title, startDate, UUID.randomUUID(), author);
+        return new TravelPlan(title, startDate, shareKey, author);
+    }
+
+    public TravelPlan get(Member author) {
+        return new TravelPlan(title, startDate, shareKey, author);
+    }
+
+    public TravelPlan get(Member author, LocalDate startDate) {
+        return new TravelPlan(title, startDate, shareKey, author);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -18,6 +18,7 @@ import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
 import kr.touroot.travelplan.dto.response.PlanResponse;
 import kr.touroot.travelplan.helper.TravelPlanTestHelper;
+import kr.touroot.travelplan.repository.TravelPlanRepository;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +40,7 @@ class TravelPlanFacadeServiceTest {
     private final TravelPlanFacadeService travelPlanFacadeService;
     private final DatabaseCleaner databaseCleaner;
     private final TravelPlanTestHelper testHelper;
+    private final TravelPlanRepository travelPlanRepository;
 
     private MemberAuth memberAuth;
     private Member author;
@@ -47,11 +49,13 @@ class TravelPlanFacadeServiceTest {
     public TravelPlanFacadeServiceTest(
             TravelPlanFacadeService travelPlanFacadeService,
             DatabaseCleaner databaseCleaner,
-            TravelPlanTestHelper testHelper
+            TravelPlanTestHelper testHelper,
+            TravelPlanRepository travelPlanRepository
     ) {
         this.travelPlanFacadeService = travelPlanFacadeService;
         this.databaseCleaner = databaseCleaner;
         this.testHelper = testHelper;
+        this.travelPlanRepository = travelPlanRepository;
     }
 
     @BeforeEach
@@ -132,8 +136,22 @@ class TravelPlanFacadeServiceTest {
 
         // when
         travelPlanFacadeService.updateTravelPlanById(travelPlan.getId(), memberAuth, request);
-        PlanResponse updated = travelPlanFacadeService.findTravelPlanById(travelPlan.getId(), memberAuth);
-        // & then
-        assertThat(updated.title()).isEqualTo("수정된 한강 여행");
+        TravelPlan updated = travelPlanRepository.findById(travelPlan.getId()).get();
+        
+        // then
+        assertThat(updated.getTitle()).isEqualTo("수정된 한강 여행");
+    }
+
+    @DisplayName("여행계획을 ID 기준으로 삭제할 수 있다.")
+    @Test
+    void deleteTravelPlanById() {
+        // given
+        TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
+
+        // when
+        travelPlanFacadeService.deleteTravelPlanById(travelPlan.getId(), memberAuth);
+
+        // then
+        assertThat(travelPlanRepository.findById(travelPlan.getId()).isEmpty());
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -15,6 +15,7 @@ import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
 import kr.touroot.travelplan.dto.request.PlanPositionRequest;
 import kr.touroot.travelplan.dto.request.PlanRequest;
 import kr.touroot.travelplan.dto.response.PlanCreateResponse;
+import kr.touroot.travelplan.dto.response.PlanResponse;
 import kr.touroot.travelplan.helper.TravelPlanTestHelper;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,5 +83,18 @@ class TravelPlanFacadeServiceTest {
 
         // then
         assertThat(actual.id()).isEqualTo(1L);
+    }
+
+    @DisplayName("여행 계획 서비스는 여행 계획 조회 시 상세 정보를 반환한다.")
+    @Test
+    void readTravelPlan() {
+        // given
+        Long id = testHelper.initTravelPlanTestData(author).getId();
+
+        // when
+        PlanResponse actual = travelPlanFacadeService.findTravelPlanById(id, memberAuth);
+
+        // then
+        assertThat(actual.id()).isEqualTo(id);
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
-// TODO: 존재하지 않는 여행계획 수정 삭제 테스트
 @DisplayName("여행 계획 파사드 서비스 테스트")
 @Import({
         TravelPlanFacadeService.class,
@@ -67,7 +66,7 @@ class TravelPlanFacadeServiceTest {
         memberAuth = new MemberAuth(author.getId());
     }
 
-    @DisplayName("여행 계획 서비스는 여행 계획 생성 시 생성된 id를 응답한다.")
+    @DisplayName("여행 계획 생성 시 생성된 id를 응답한다.")
     @Test
     void createTravelPlan() {
         // given
@@ -91,7 +90,7 @@ class TravelPlanFacadeServiceTest {
         assertThat(actual.id()).isEqualTo(1L);
     }
 
-    @DisplayName("여행 계획 서비스는 여행 계획 조회 시 상세 정보를 반환한다.")
+    @DisplayName("여행 계획 상세 정보를 조회할 수 있다")
     @Test
     void readTravelPlan() {
         // given
@@ -104,7 +103,7 @@ class TravelPlanFacadeServiceTest {
         assertThat(actual.id()).isEqualTo(id);
     }
 
-    @DisplayName("여행 계획 서비스는 공유 키로 여행 계획을 조회할 수 있다")
+    @DisplayName("공유 키로 여행 계획을 조회할 수 있다")
     @Test
     void readTravelPlanByShareKey() {
         // given
@@ -117,7 +116,7 @@ class TravelPlanFacadeServiceTest {
         assertThat(actual.shareKey()).isEqualTo(travelPlan.getShareKey());
     }
 
-    @DisplayName("여행 계획 서비스는 새로운 정보로 여행 계획을 수정한다.")
+    @DisplayName("새로운 정보로 여행 계획을 수정할 수 있다")
     @Test
     void updateTravelPlan() {
         // given
@@ -143,7 +142,7 @@ class TravelPlanFacadeServiceTest {
         assertThat(updated.getTitle()).isEqualTo("수정된 한강 여행");
     }
 
-    @DisplayName("여행계획을 ID 기준으로 삭제할 수 있다.")
+    @DisplayName("여행 계획을 삭제할 수 있다")
     @Test
     void deleteTravelPlanById() {
         // given

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -99,6 +99,19 @@ class TravelPlanFacadeServiceTest {
         assertThat(actual.id()).isEqualTo(id);
     }
 
+    @DisplayName("여행 계획 서비스는 공유 키로 여행 계획을 조회할 수 있다")
+    @Test
+    void readTravelPlanByShareKey() {
+        // given
+        TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
+
+        // when
+        PlanResponse actual = travelPlanFacadeService.findTravelPlanByShareKey(travelPlan.getShareKey());
+
+        // then
+        assertThat(actual.shareKey()).isEqualTo(travelPlan.getShareKey());
+    }
+
     @DisplayName("여행 계획 서비스는 새로운 정보로 여행 계획을 수정한다.")
     @Test
     void updateTravelPlan() {

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -1,0 +1,86 @@
+package kr.touroot.travelplan.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import kr.touroot.authentication.infrastructure.PasswordEncryptor;
+import kr.touroot.global.ServiceTest;
+import kr.touroot.global.auth.dto.MemberAuth;
+import kr.touroot.member.domain.Member;
+import kr.touroot.member.service.MemberService;
+import kr.touroot.travelplan.dto.request.PlanDayRequest;
+import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
+import kr.touroot.travelplan.dto.request.PlanPositionRequest;
+import kr.touroot.travelplan.dto.request.PlanRequest;
+import kr.touroot.travelplan.dto.response.PlanCreateResponse;
+import kr.touroot.travelplan.helper.TravelPlanTestHelper;
+import kr.touroot.utils.DatabaseCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@DisplayName("여행 계획 파사드 서비스 테스트")
+@Import({
+        TravelPlanFacadeService.class,
+        TravelPlanService.class,
+        MemberService.class,
+        PasswordEncryptor.class,
+        TravelPlanTestHelper.class
+})
+@ServiceTest
+class TravelPlanFacadeServiceTest {
+
+    private final TravelPlanFacadeService travelPlanFacadeService;
+    private final DatabaseCleaner databaseCleaner;
+    private final TravelPlanTestHelper testHelper;
+
+    private MemberAuth memberAuth;
+    private Member author;
+
+    @Autowired
+    public TravelPlanFacadeServiceTest(
+            TravelPlanFacadeService travelPlanFacadeService,
+            DatabaseCleaner databaseCleaner,
+            TravelPlanTestHelper testHelper
+    ) {
+        this.travelPlanFacadeService = travelPlanFacadeService;
+        this.databaseCleaner = databaseCleaner;
+        this.testHelper = testHelper;
+    }
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.executeTruncate();
+
+        author = testHelper.initMemberTestData();
+        memberAuth = new MemberAuth(author.getId());
+    }
+
+    @DisplayName("여행 계획 서비스는 여행 계획 생성 시 생성된 id를 응답한다.")
+    @Test
+    void createTravelPlan() {
+        // given
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
+                .title("신나는 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayRequest))
+                .build();
+
+        // when
+        PlanCreateResponse actual = travelPlanFacadeService.createTravelPlan(request, memberAuth);
+
+        // then
+        assertThat(actual.id()).isEqualTo(1L);
+    }
+}

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
+// TODO: 존재하지 않는 여행계획 수정 삭제 테스트
 @DisplayName("여행 계획 파사드 서비스 테스트")
 @Import({
         TravelPlanFacadeService.class,
@@ -137,7 +138,7 @@ class TravelPlanFacadeServiceTest {
         // when
         travelPlanFacadeService.updateTravelPlanById(travelPlan.getId(), memberAuth, request);
         TravelPlan updated = travelPlanRepository.findById(travelPlan.getId()).get();
-        
+
         // then
         assertThat(updated.getTitle()).isEqualTo("수정된 한강 여행");
     }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -10,6 +10,7 @@ import kr.touroot.global.ServiceTest;
 import kr.touroot.global.auth.dto.MemberAuth;
 import kr.touroot.member.domain.Member;
 import kr.touroot.member.service.MemberService;
+import kr.touroot.travelplan.domain.TravelPlan;
 import kr.touroot.travelplan.dto.request.PlanDayRequest;
 import kr.touroot.travelplan.dto.request.PlanPlaceRequest;
 import kr.touroot.travelplan.dto.request.PlanPositionRequest;
@@ -96,5 +97,30 @@ class TravelPlanFacadeServiceTest {
 
         // then
         assertThat(actual.id()).isEqualTo(id);
+    }
+
+    @DisplayName("여행 계획 서비스는 새로운 정보로 여행 계획을 수정한다.")
+    @Test
+    void updateTravelPlan() {
+        // given
+        TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
+        PlanPositionRequest locationRequest = new PlanPositionRequest("37.5175896", "127.0867236");
+        PlanPlaceRequest planPlaceRequest = PlanPlaceRequest.builder()
+                .placeName("잠실한강공원")
+                .todos(Collections.EMPTY_LIST)
+                .position(locationRequest)
+                .build();
+        PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
+        PlanRequest request = PlanRequest.builder()
+                .title("수정된 한강 여행")
+                .startDate(LocalDate.MAX)
+                .days(List.of(planDayRequest))
+                .build();
+
+        // when
+        travelPlanFacadeService.updateTravelPlanById(travelPlan.getId(), memberAuth, request);
+        PlanResponse updated = travelPlanFacadeService.findTravelPlanById(travelPlan.getId(), memberAuth);
+        // & then
+        assertThat(updated.title()).isEqualTo("수정된 한강 여행");
     }
 }

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -171,19 +171,6 @@ class TravelPlanServiceTest {
                 .hasMessage("여행 계획 조회는 작성자만 가능합니다.");
     }
 
-    @DisplayName("여행 계획 서비스는 여행 계획 일자를 계산해 반환한다.")
-    @Test
-    void calculateTravelPeriod() {
-        // given
-        TravelPlan travelPlan = testHelper.initTravelPlanTestData(author);
-
-        // when
-        int actual = travelPlanService.calculateTravelPeriod(travelPlan);
-
-        // then
-        assertThat(actual).isEqualTo(1);
-    }
-
     @DisplayName("여행 계획 서비스는 새로운 정보로 여행 계획을 수정한다.")
     @Test
     void updateTravelPlan() {

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -75,7 +75,7 @@ class TravelPlanServiceTest {
         assertThat(actual.getId()).isEqualTo(1L);
     }
 
-    @DisplayName("여행 계획 서비스는 지난 날짜로 여행 계획 생성 시 예외를 반환한다.")
+    @DisplayName("지난 날짜로 여행 계획 저장 시 예외를 반환한다.")
     @Test
     void createTravelPlanWithInvalidStartDate() {
         // given
@@ -99,7 +99,7 @@ class TravelPlanServiceTest {
                 .doesNotThrowAnyException();
     }
 
-    @DisplayName("여행 계획 상세 정보를 조회할 수 있다")
+    @DisplayName("여행 계획을 가져올 수 있다")
     @Test
     void readTravelPlan() {
         // given
@@ -112,7 +112,7 @@ class TravelPlanServiceTest {
         assertThat(actual.getId()).isEqualTo(id);
     }
 
-    @DisplayName("여행 계획 서비스는 존재하지 않는 여행 계획 조회 시 예외를 반환한다.")
+    @DisplayName("존재하지 않는 여행 계획을 가져오려고 할 경우 예외를 반환한다.")
     @Test
     void readTravelPlanWitNonExist() {
         // given
@@ -124,7 +124,7 @@ class TravelPlanServiceTest {
                 .hasMessage("존재하지 않는 여행 계획입니다.");
     }
 
-    @DisplayName("여행 계획 서비스는 작성자가 아닌 사용자가 조회 시 예외를 반환한다.")
+    @DisplayName("작성자가 아닌 사용자가 여행 계획을 가져오려고 하는 경우 예외를 반환한다.")
     @Test
     void readTravelPlanWithNotAuthor() {
         // given
@@ -137,7 +137,7 @@ class TravelPlanServiceTest {
                 .hasMessage("여행 계획은 작성자만 접근 가능합니다.");
     }
 
-    @DisplayName("여행 계획 서비스는 새로운 정보로 여행 계획을 수정한다.")
+    @DisplayName("새로운 정보로 여행 계획을 수정할 수 있다")
     @Test
     void updateTravelPlan() {
         // given
@@ -163,7 +163,7 @@ class TravelPlanServiceTest {
         assertThat(updated.getTitle()).isEqualTo("수정된 한강 여행");
     }
 
-    @DisplayName("여행 계획 서비스는 작성자가 아닌 사용자가 수정 시 예외를 반환한다.")
+    @DisplayName("작성자가 아닌 사용자가 여행 계획 수정 시도 시 예외를 반환한다.")
     @Test
     void updateTravelPlanWithNotAuthor() {
         // given
@@ -189,7 +189,7 @@ class TravelPlanServiceTest {
                 .hasMessage("여행 계획은 작성자만 접근 가능합니다.");
     }
 
-    @DisplayName("여행계획을 삭제할 수 있다.")
+    @DisplayName("여행 계획을 삭제할 수 있다.")
     @Test
     void deleteTravelPlanById() {
         // given
@@ -202,7 +202,7 @@ class TravelPlanServiceTest {
                 .isEmpty();
     }
 
-    @DisplayName("여행 계획 서비스는 작성자가 아닌 사용자가 삭제 시 예외를 반환한다.")
+    @DisplayName("작성자가 아닌 사용자가 여행 계획 삭제 시 예외를 반환한다.")
     @Test
     void deleteTravelPlanWithNotAuthor() {
         // given
@@ -215,7 +215,7 @@ class TravelPlanServiceTest {
                 .hasMessage("여행 계획은 작성자만 접근 가능합니다.");
     }
 
-    @DisplayName("여행 계획 서비스는 공유 키로 여행 계획을 조회할 수 있다")
+    @DisplayName("공유 키로 여행 계획을 가져올 수 있다")
     @Test
     void readTravelPlanByShareKey() {
         // given


### PR DESCRIPTION
# ✅ 작업 내용

-  여행계획 생성 로직 양방향 연관관계 이용, 개선
- 여행계획 상세 조회 로직 양방향 연관관계 이용, 개선
- 여행계획 삭제 로직 양방향 연관관계 이용, 개선

# 🙈 참고 사항
- TravelPlanFacade가 작성되었습니다.
- 도메인을 다루는 계층을 하위 서비스로, DTO와 밀접하며 비즈니스 파사드를 관장하는 계층을 Facade 서비스로 나누었어요.
- 다만 그 의미가 미약해지고 있습니다 (by 양방향 연관관계)
- 우선은 여행기 도메인과의 통일성을 위해 진행된 작업으로 이해해주세요~