### PR TITLE
[Feature] - 검색 + 필터링 API 통합

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -141,9 +141,17 @@ public class TravelogueController {
             @Parameter(hidden = true)
             @PageableDefault(size = 5, sort = "id", direction = Direction.DESC)
             Pageable pageable,
-            TravelogueFilterRequest filter
+            TravelogueFilterRequest filterRequest,
+            @Valid
+            TravelogueSearchRequest searchRequest
+
     ) {
-        return ResponseEntity.ok(travelogueFacadeService.findSimpleTravelogues(filter, pageable));
+        Page<TravelogueSimpleResponse> data = travelogueFacadeService.findSimpleTravelogues(
+                filterRequest,
+                searchRequest,
+                pageable
+        );
+        return ResponseEntity.ok(data);
     }
 
     @Operation(summary = "여행기 검색")

--- a/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
+++ b/backend/src/main/java/kr/touroot/travelogue/controller/TravelogueController.java
@@ -154,6 +154,7 @@ public class TravelogueController {
         return ResponseEntity.ok(data);
     }
 
+    // TODO: 프론트엔드 엔드포인트 이전 작업 완료 후 제거
     @Operation(summary = "여행기 검색")
     @ApiResponses(value = {
             @ApiResponse(

--- a/backend/src/main/java/kr/touroot/travelogue/domain/search/SearchCondition.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/search/SearchCondition.java
@@ -12,4 +12,8 @@ public class SearchCondition {
         this.keyword = keyword;
         this.searchType = searchType;
     }
+
+    public boolean isEmptyCondition() {
+        return keyword == null && searchType == null;
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueSearchRequest.java
+++ b/backend/src/main/java/kr/touroot/travelogue/dto/request/TravelogueSearchRequest.java
@@ -1,16 +1,27 @@
 package kr.touroot.travelogue.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import kr.touroot.travelogue.domain.search.SearchCondition;
+import kr.touroot.travelogue.domain.search.SearchType;
 
 public record TravelogueSearchRequest(
         @Schema(description = "검색어 (제목, 작성자 닉네임 모두 가능)", example = "서울")
-        @NotBlank(message = "검색어는 2글자 이상이어야 합니다.")
         @Size(min = 2, message = "검색어는 2글자 이상이어야 합니다.")
         String keyword,
         @Schema(description = "검색 키워드 종류 (TITLE, AUTHOR, COUNTRY)", example = "TITLE")
-        @NotBlank(message = "검색 키워드 종류는 필수입니다.")
         String searchType
 ) {
+
+    public SearchCondition toSearchCondition() {
+        return new SearchCondition(keyword, getSearchType());
+    }
+
+    private SearchType getSearchType() {
+        if (this.searchType == null) {
+            return null;
+        }
+
+        return SearchType.from(this.searchType);
+    }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
@@ -10,7 +10,5 @@ public interface TravelogueQueryRepository {
 
     Page<Travelogue> findAllBySearchCondition(SearchCondition condition, Pageable pageable);
 
-    Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable);
-
     Page<Travelogue> findAllByCondition(SearchCondition searchCondition, TravelogueFilterCondition filterCondition, Pageable pageable);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface TravelogueQueryRepository {
 
-    Page<Travelogue> findByKeywordAndSearchType(SearchCondition condition, Pageable pageable);
+    Page<Travelogue> findAllBySearchCondition(SearchCondition condition, Pageable pageable);
 
     Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable);
+
+    Page<Travelogue> findAllByCondition(SearchCondition searchCondition, TravelogueFilterCondition filterCondition, Pageable pageable);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
@@ -112,21 +112,6 @@ public class TravelogueQueryRepositoryImpl implements TravelogueQueryRepository 
         return travelogue.title;
     }
 
-    @Override
-    public Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable) {
-        JPAQuery<Travelogue> query = jpaQueryFactory.selectFrom(travelogue);
-
-        addTagFilter(query, filter);
-        addPeriodFilter(query, filter);
-
-        List<Travelogue> results = query.orderBy(findSortCondition(pageable.getSort()))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        return new PageImpl<>(results, pageable, results.size());
-    }
-
     public void addTagFilter(JPAQuery<Travelogue> query, TravelogueFilterCondition filter) {
         if (filter.isEmptyTagCondition()) {
             return;

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
@@ -71,47 +71,6 @@ public class TravelogueQueryRepositoryImpl implements TravelogueQueryRepository 
         addPeriodFilter(query, filter);
     }
 
-    @Override
-    public Page<Travelogue> findAllBySearchCondition(SearchCondition condition, Pageable pageable) {
-        String keyword = condition.getKeyword();
-        JPAQuery<Travelogue> query = jpaQueryFactory.selectFrom(travelogue);
-
-        if (condition.getSearchType() == SearchType.COUNTRY) {
-            CountryCode countryCode = CountryCode.findByName(keyword);
-            findByCountryCode(query, countryCode);
-        }
-
-        if (condition.getSearchType() == SearchType.AUTHOR || condition.getSearchType() == SearchType.TITLE) {
-            findByTitleOrAuthor(condition, query, keyword);
-        }
-
-        List<Travelogue> results = query.offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        return new PageImpl<>(results, pageable, results.size());
-    }
-
-    private void findByCountryCode(JPAQuery<Travelogue> query, CountryCode countryCode) {
-        query.join(travelogueCountry)
-                .on(travelogue.id.eq(travelogueCountry.travelogue.id))
-                .where(travelogueCountry.countryCode.eq(countryCode))
-                .orderBy(travelogueCountry.count.desc());
-    }
-
-    private void findByTitleOrAuthor(SearchCondition condition, JPAQuery<Travelogue> query, String keyword) {
-        query.where(Expressions.stringTemplate(TEMPLATE, getTargetField(condition.getSearchType()))
-                        .containsIgnoreCase(keyword.replace(BLANK, EMPTY)))
-                .orderBy(travelogue.id.desc());
-    }
-
-    private StringPath getTargetField(SearchType searchType) {
-        if (SearchType.AUTHOR.equals(searchType)) {
-            return travelogue.author.nickname;
-        }
-        return travelogue.title;
-    }
-
     public void addTagFilter(JPAQuery<Travelogue> query, TravelogueFilterCondition filter) {
         if (filter.isEmptyTagCondition()) {
             return;
@@ -157,5 +116,47 @@ public class TravelogueQueryRepositoryImpl implements TravelogueQueryRepository 
         }
 
         return Order.DESC;
+    }
+
+    // TODO: /travelogues/search 엔드포인트 제거 시 함께 제거
+    @Override
+    public Page<Travelogue> findAllBySearchCondition(SearchCondition condition, Pageable pageable) {
+        String keyword = condition.getKeyword();
+        JPAQuery<Travelogue> query = jpaQueryFactory.selectFrom(travelogue);
+
+        if (condition.getSearchType() == SearchType.COUNTRY) {
+            CountryCode countryCode = CountryCode.findByName(keyword);
+            findByCountryCode(query, countryCode);
+        }
+
+        if (condition.getSearchType() == SearchType.AUTHOR || condition.getSearchType() == SearchType.TITLE) {
+            findByTitleOrAuthor(condition, query, keyword);
+        }
+
+        List<Travelogue> results = query.offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(results, pageable, results.size());
+    }
+
+    private void findByCountryCode(JPAQuery<Travelogue> query, CountryCode countryCode) {
+        query.join(travelogueCountry)
+                .on(travelogue.id.eq(travelogueCountry.travelogue.id))
+                .where(travelogueCountry.countryCode.eq(countryCode))
+                .orderBy(travelogueCountry.count.desc());
+    }
+
+    private void findByTitleOrAuthor(SearchCondition condition, JPAQuery<Travelogue> query, String keyword) {
+        query.where(Expressions.stringTemplate(TEMPLATE, getTargetField(condition.getSearchType()))
+                        .containsIgnoreCase(keyword.replace(BLANK, EMPTY)))
+                .orderBy(travelogue.id.desc());
+    }
+
+    private StringPath getTargetField(SearchType searchType) {
+        if (SearchType.AUTHOR.equals(searchType)) {
+            return travelogue.author.nickname;
+        }
+        return travelogue.title;
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -64,17 +64,6 @@ public class TravelogueFacadeService {
     @Transactional(readOnly = true)
     public Page<TravelogueSimpleResponse> findSimpleTravelogues(
             TravelogueFilterRequest filterRequest,
-            Pageable pageable
-    ) {
-        TravelogueFilterCondition filter = filterRequest.toFilterCondition();
-        Page<Travelogue> travelogues = travelogueService.findAllByFilter(filter, pageable);
-
-        return travelogues.map(this::getTravelogueSimpleResponse);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<TravelogueSimpleResponse> findSimpleTravelogues(
-            TravelogueFilterRequest filterRequest,
             TravelogueSearchRequest searchRequest,
             Pageable pageable
     ) {

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -7,6 +7,7 @@ import kr.touroot.member.service.MemberService;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueFilterCondition;
 import kr.touroot.travelogue.domain.TravelogueTag;
+import kr.touroot.travelogue.domain.search.SearchCondition;
 import kr.touroot.travelogue.dto.request.TravelogueFilterRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
 import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
@@ -67,6 +68,19 @@ public class TravelogueFacadeService {
     ) {
         TravelogueFilterCondition filter = filterRequest.toFilterCondition();
         Page<Travelogue> travelogues = travelogueService.findAllByFilter(filter, pageable);
+
+        return travelogues.map(this::getTravelogueSimpleResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TravelogueSimpleResponse> findSimpleTravelogues(
+            TravelogueFilterRequest filterRequest,
+            TravelogueSearchRequest searchRequest,
+            Pageable pageable
+    ) {
+        TravelogueFilterCondition filter = filterRequest.toFilterCondition();
+        SearchCondition searchCondition = searchRequest.toSearchCondition();
+        Page<Travelogue> travelogues = travelogueService.findAll(searchCondition, filter, pageable);
 
         return travelogues.map(this::getTravelogueSimpleResponse);
     }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -74,6 +74,7 @@ public class TravelogueFacadeService {
         return travelogues.map(this::getTravelogueSimpleResponse);
     }
 
+    // TODO: 프론트엔드 엔드포인트 이전 작업 완료 후 제거
     @Transactional(readOnly = true)
     public Page<TravelogueSimpleResponse> findSimpleTravelogues(TravelogueSearchRequest request, Pageable pageable) {
         Page<Travelogue> travelogues = travelogueService.findByKeyword(request, pageable);

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -45,7 +45,7 @@ public class TravelogueService {
         SearchType searchType = SearchType.from(request.searchType());
         SearchCondition searchCondition = new SearchCondition(request.keyword(), searchType);
 
-        return travelogueQueryRepository.findByKeywordAndSearchType(searchCondition, pageable);
+        return travelogueQueryRepository.findAllBySearchCondition(searchCondition, pageable);
     }
 
     @Transactional(readOnly = true)
@@ -55,6 +55,19 @@ public class TravelogueService {
         }
 
         return travelogueQueryRepository.findAllByFilter(filter, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Travelogue> findAll(
+            SearchCondition searchCondition,
+            TravelogueFilterCondition filter,
+            Pageable pageable
+    ) {
+        if (filter.isEmptyCondition() && searchCondition.isEmptyCondition()) {
+            return travelogueRepository.findAll(pageable);
+        }
+
+        return travelogueQueryRepository.findAllByCondition(searchCondition, filter, pageable);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -49,15 +49,6 @@ public class TravelogueService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Travelogue> findAllByFilter(TravelogueFilterCondition filter, Pageable pageable) {
-        if (filter.isEmptyCondition()) {
-            return travelogueRepository.findAll(pageable);
-        }
-
-        return travelogueQueryRepository.findAllByFilter(filter, pageable);
-    }
-
-    @Transactional(readOnly = true)
     public Page<Travelogue> findAll(
             SearchCondition searchCondition,
             TravelogueFilterCondition filter,

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueService.java
@@ -40,6 +40,7 @@ public class TravelogueService {
         return travelogueRepository.findAllByAuthor(member, pageable);
     }
 
+    // TODO: 프론트엔드 엔드포인트 이전 작업 완료 후 제거
     @Transactional(readOnly = true)
     public Page<Travelogue> findByKeyword(TravelogueSearchRequest request, Pageable pageable) {
         SearchType searchType = SearchType.from(request.searchType());

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -390,7 +390,7 @@ class TravelogueControllerTest {
                 .param("searchType", "TITLE")
                 .log().all()
                 .accept(ContentType.JSON)
-                .when().get("/api/v1/travelogues/search")
+                .when().get("/api/v1/travelogues")
                 .then().log().all()
                 .statusCode(200).assertThat()
                 .body(is(objectMapper.writeValueAsString(responses)));
@@ -408,7 +408,7 @@ class TravelogueControllerTest {
                 .param("searchType", "TITLE")
                 .log().all()
                 .accept(ContentType.JSON)
-                .when().get("/api/v1/travelogues/search")
+                .when().get("/api/v1/travelogues")
                 .then().log().all()
                 .statusCode(400).assertThat()
                 .body("message", is("검색어는 2글자 이상이어야 합니다."));
@@ -426,7 +426,7 @@ class TravelogueControllerTest {
                 .param("searchType", "TITLE")
                 .log().all()
                 .accept(ContentType.JSON)
-                .when().get("/api/v1/travelogues/search")
+                .when().get("/api/v1/travelogues")
                 .then().log().all()
                 .statusCode(200).assertThat()
                 .body(is(objectMapper.writeValueAsString(responses)));

--- a/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/controller/TravelogueControllerTest.java
@@ -28,6 +28,7 @@ import kr.touroot.travelogue.fixture.TravelogueResponseFixture;
 import kr.touroot.travelogue.helper.TravelogueTestHelper;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -431,6 +432,7 @@ class TravelogueControllerTest {
                 .body(is(objectMapper.writeValueAsString(responses)));
     }
 
+    @Disabled // 검색과 필터링 API 통합으로 검색 키워드 빈 값 가능
     @DisplayName("검색 키워드의 종류를 명시해야 한다.")
     @Test
     void findTraveloguesByKeywordWithoutSearchType() {

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -147,12 +147,13 @@ class TravelogueFacadeServiceTest {
     @DisplayName("메인 페이지에 표시할 여행기 목록을 조회한다.")
     @Test
     void findTravelogues() {
+        TravelogueSearchRequest searchRequest = new TravelogueSearchRequest(null, null);
         TravelogueFilterRequest filterRequest = new TravelogueFilterRequest(null, null);
         testHelper.initAllTravelogueTestData();
         Page<TravelogueSimpleResponse> expect = TravelogueResponseFixture.getTravelogueSimpleResponses();
 
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
-        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(filterRequest, pageRequest);
+        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(filterRequest, searchRequest, pageRequest);
 
         assertThat(result).containsAll(expect);
     }
@@ -164,9 +165,10 @@ class TravelogueFacadeServiceTest {
         testHelper.initAllTravelogueTestData();
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
         TravelogueFilterRequest filter = new TravelogueFilterRequest(List.of(1L), null);
+        TravelogueSearchRequest searchRequest = new TravelogueSearchRequest(null, null);
 
         // when
-        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(filter, pageRequest);
+        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(filter, searchRequest, pageRequest);
 
         // then
         assertThat(result.getContent()).hasSize(1);

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -153,7 +153,11 @@ class TravelogueFacadeServiceTest {
         Page<TravelogueSimpleResponse> expect = TravelogueResponseFixture.getTravelogueSimpleResponses();
 
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
-        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(filterRequest, searchRequest, pageRequest);
+        Page<TravelogueSimpleResponse> result = service.findSimpleTravelogues(
+                filterRequest,
+                searchRequest,
+                pageRequest
+        );
 
         assertThat(result).containsAll(expect);
     }
@@ -177,39 +181,62 @@ class TravelogueFacadeServiceTest {
     @DisplayName("제목 키워드를 기반으로 여행기 목록을 조회한다.")
     @Test
     void findTraveloguesByTitleKeyword() {
+        // given
         testHelper.initAllTravelogueTestData();
         Page<TravelogueSimpleResponse> responses = TravelogueResponseFixture.getTravelogueSimpleResponses();
 
         TravelogueSearchRequest searchRequest = new TravelogueSearchRequest("제주", "title");
+        TravelogueFilterRequest filterRequest = new TravelogueFilterRequest(null, null);
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
-        Page<TravelogueSimpleResponse> searchResults = service.findSimpleTravelogues(searchRequest, pageRequest);
 
+        // when
+        Page<TravelogueSimpleResponse> searchResults = service.findSimpleTravelogues(
+                filterRequest,
+                searchRequest,
+                pageRequest
+        );
+
+        // then
         assertThat(searchResults).containsAll(responses);
     }
 
     @DisplayName("사용자 닉네임을 기반으로 여행기 목록을 조회한다.")
     @Test
     void findTraveloguesByAuthorNicknameKeyword() {
+        // given
         testHelper.initAllTravelogueTestData();
         Page<TravelogueSimpleResponse> responses = TravelogueResponseFixture.getTravelogueSimpleResponses();
 
         TravelogueSearchRequest searchRequest = new TravelogueSearchRequest("리비", "author");
+        TravelogueFilterRequest filterRequest = new TravelogueFilterRequest(null, null);
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
-        Page<TravelogueSimpleResponse> searchResults = service.findSimpleTravelogues(searchRequest, pageRequest);
 
+        // when
+        Page<TravelogueSimpleResponse> searchResults = service.findSimpleTravelogues(
+                filterRequest,
+                searchRequest,
+                pageRequest
+        );
+
+        // then
         assertThat(searchResults).containsAll(responses);
     }
 
     @DisplayName("국가 코드를 기반으로 여행기 목록을 조회한다.")
     @Test
     void findTraveloguesByCountryCodeKeyword() {
+        // given
         testHelper.initAllTravelogueTestData();
         Page<TravelogueSimpleResponse> responses = TravelogueResponseFixture.getTravelogueSimpleResponses();
 
         TravelogueSearchRequest searchRequest = new TravelogueSearchRequest("한국", "country");
+        TravelogueFilterRequest filterRequest = new TravelogueFilterRequest(null, null);
         PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("id"));
-        Page<TravelogueSimpleResponse> searchResults = service.findSimpleTravelogues(searchRequest, pageRequest);
 
+        // when
+        Page<TravelogueSimpleResponse> searchResults = service.findSimpleTravelogues(filterRequest, searchRequest, pageRequest);
+
+        // then
         assertThat(searchResults).containsAll(responses);
     }
 

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueServiceTest.java
@@ -12,11 +12,13 @@ import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.global.exception.ForbiddenException;
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.domain.TravelogueFilterCondition;
+import kr.touroot.travelogue.domain.search.SearchCondition;
+import kr.touroot.travelogue.domain.search.SearchType;
 import kr.touroot.travelogue.dto.request.TravelogueDayRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePhotoRequest;
 import kr.touroot.travelogue.dto.request.TraveloguePlaceRequest;
 import kr.touroot.travelogue.dto.request.TravelogueRequest;
-import kr.touroot.travelogue.dto.request.TravelogueSearchRequest;
 import kr.touroot.travelogue.fixture.TravelogueFixture;
 import kr.touroot.travelogue.fixture.TravelogueRequestFixture;
 import kr.touroot.travelogue.helper.TravelogueTestHelper;
@@ -26,7 +28,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 @DisplayName("여행기 서비스")
 @Import(value = {TravelogueService.class, TravelogueTestHelper.class, TestQueryDslConfig.class})
@@ -90,21 +94,35 @@ class TravelogueServiceTest {
     @DisplayName("여행기를 검색할 수 있다.")
     @Test
     void findByKeyword() {
+        // given
         testHelper.initTravelogueTestData();
-        TravelogueSearchRequest request = new TravelogueSearchRequest("제주", "title");
 
-        assertThat(travelogueService.findByKeyword(request, Pageable.ofSize(BASIC_PAGE_SIZE)))
-                .hasSize(1);
+        SearchCondition searchCondition = new SearchCondition("제주", SearchType.TITLE);
+        TravelogueFilterCondition filter = new TravelogueFilterCondition(null, null);
+        PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("createdAt"));
+
+        // when
+        Page<Travelogue> actual = travelogueService.findAll(searchCondition, filter, pageRequest);
+
+        // then
+        assertThat(actual).hasSize(1);
     }
 
     @DisplayName("존재하지 않는 키워드로 여행기를 조회하면 빈 페이지가 반환된다.")
     @Test
     void findByKeywordWithNotExistRequest() {
+        // given
         testHelper.initTravelogueTestData();
-        TravelogueSearchRequest request = new TravelogueSearchRequest("서울", "title");
 
-        assertThat(travelogueService.findByKeyword(request, Pageable.ofSize(BASIC_PAGE_SIZE)))
-                .isEmpty();
+        SearchCondition searchCondition = new SearchCondition("서울", SearchType.TITLE);
+        TravelogueFilterCondition filter = new TravelogueFilterCondition(null, null);
+        PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("createdAt"));
+
+        // when
+        Page<Travelogue> actual = travelogueService.findAll(searchCondition, filter, pageRequest);
+
+        // then
+        assertThat(actual).isEmpty();
     }
 
     @DisplayName("여행기를 수정할 수 있다.")


### PR DESCRIPTION
# ✅ 작업 내용

- 검색 + 필터링 API 통합

# 🙈 참고 사항

- 프론트 측과의 API 싱크를 맞추기 위해 `/search` 엔드포인트와 관련된 메서드를 살려뒀습니다. 대신 테스트는 전부 통합된 메서드로 변경해둬 삭제 결정되면 바로 삭제될 수 있게 처리해뒀습니다.
- 슬랙에 올렸던 정렬이 충돌나는 문제에 대해서도 일단은 `sort` 파라미터로 들어온 정렬이 후순위로 적용되게 해두었습니다. 다만 이것도 변경 요청 시 기존 정렬을 모두 제거하는 식으로 금방 처리할 수 있을 것 같아요.

위의 두 참고사항에 대해서 어떤 처리가 나을지 의견 남겨주세요~ 
슬랙에서도 얘기 나왔지만 여기에 제대로 의사결정 과정 기록해두면 좋을 것 같습니다. 👍 