### PR TITLE
[Fix] - 사용하지 않는 정렬 쿼리 삭제

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
@@ -69,8 +69,7 @@ public class TravelogueQueryRepositoryImpl implements TravelogueQueryRepository 
     private void findByCountryCode(JPAQuery<Travelogue> query, CountryCode countryCode) {
         query.join(travelogueCountry)
                 .on(travelogue.id.eq(travelogueCountry.travelogue.id))
-                .where(travelogueCountry.countryCode.eq(countryCode))
-                .orderBy(travelogueCountry.count.desc());
+                .where(travelogueCountry.countryCode.eq(countryCode));
     }
 
     private void findByTitleOrAuthor(SearchCondition condition, JPAQuery<Travelogue> query, String keyword) {


### PR DESCRIPTION
# ✅ 작업 내용

- travelogue_country.count로 정렬하는 조건 삭제