### PR TITLE
https://github.com/woowacourse-teams/2024-touroot/issues/622

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,11 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // testcontainers
+    testImplementation "org.testcontainers:testcontainers:1.20.4"
+    testImplementation "org.testcontainers:junit-jupiter:1.20.4"
+    testImplementation "org.testcontainers:mysql"
+
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.20.4"
     testImplementation "org.testcontainers:junit-jupiter:1.20.4"
     testImplementation "org.testcontainers:mysql"
+    testImplementation 'org.testcontainers:localstack'
 
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/backend/src/main/java/kr/touroot/global/config/EmbeddedS3Config.java
+++ b/backend/src/main/java/kr/touroot/global/config/EmbeddedS3Config.java
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 @Configuration
-@Profile({"default", "local"})
+@Profile("local")
 public class EmbeddedS3Config {
 
     private static final int DYNAMIC_PORT_NUMBER_LOWER = 49152;

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -85,6 +85,12 @@
         </rollingPolicy>
     </appender>
 
+    <springProfile name="default">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -85,7 +85,7 @@
         </rollingPolicy>
     </appender>
 
-    <springProfile name="default">
+    <springProfile name="test">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>

--- a/backend/src/test/java/kr/touroot/global/AcceptanceTest.java
+++ b/backend/src/test/java/kr/touroot/global/AcceptanceTest.java
@@ -4,10 +4,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Retention(RetentionPolicy.RUNTIME)
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@ActiveProfiles("test")
 public @interface AcceptanceTest {
 }

--- a/backend/src/test/java/kr/touroot/global/ServiceTest.java
+++ b/backend/src/test/java/kr/touroot/global/ServiceTest.java
@@ -3,6 +3,7 @@ package kr.touroot.global;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import kr.touroot.utils.DatabaseCleaner;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 @Import(value = {DatabaseCleaner.class})
 @Retention(RetentionPolicy.RUNTIME)

--- a/backend/src/test/java/kr/touroot/global/ServiceTest.java
+++ b/backend/src/test/java/kr/touroot/global/ServiceTest.java
@@ -6,6 +6,7 @@ import kr.touroot.utils.DatabaseCleaner;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,5 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(value = {DatabaseCleaner.class})
 @Retention(RetentionPolicy.RUNTIME)
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@ActiveProfiles("test")
 public @interface ServiceTest {
 }

--- a/backend/src/test/java/kr/touroot/global/config/S3TestConfig.java
+++ b/backend/src/test/java/kr/touroot/global/config/S3TestConfig.java
@@ -15,7 +15,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 @Configuration
-@Profile("default")
+@Profile("test")
 public class S3TestConfig {
 
     @Value("${cloud.aws.s3.bucket}")

--- a/backend/src/test/java/kr/touroot/global/config/S3TestConfig.java
+++ b/backend/src/test/java/kr/touroot/global/config/S3TestConfig.java
@@ -1,0 +1,45 @@
+package kr.touroot.global.config;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Configuration
+@Profile("default")
+public class S3TestConfig {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private static final DockerImageName LOCAL_STACK_IMAGE = DockerImageName.parse("localstack/localstack");
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    public LocalStackContainer localStackContainer() {
+        return new LocalStackContainer(LOCAL_STACK_IMAGE).withServices(S3);
+    }
+
+    @Bean(name = "s3Client", destroyMethod = "close")
+    public S3Client s3Client(LocalStackContainer localStackContainer) {
+        StaticCredentialsProvider localStackContainerCredentials = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(localStackContainer.getAccessKey(), localStackContainer.getSecretKey())
+        );
+
+        S3Client s3Client = S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .endpointOverride(localStackContainer.getEndpointOverride(S3))
+                .credentialsProvider(localStackContainerCredentials)
+                .build();
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+        return s3Client;
+    }
+}

--- a/backend/src/test/java/kr/touroot/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/kr/touroot/member/service/MemberServiceTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import kr.touroot.authentication.infrastructure.PasswordEncryptor;
 import kr.touroot.global.ServiceTest;
 import kr.touroot.global.auth.dto.MemberAuth;
-import kr.touroot.global.config.EmbeddedS3Config;
+import kr.touroot.global.config.S3TestConfig;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.image.domain.ImageFile;
 import kr.touroot.image.infrastructure.AwsS3Provider;
@@ -26,9 +26,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+
 @DisplayName("사용자 서비스")
-@Import(value = {MemberService.class, MemberTestHelper.class, PasswordEncryptor.class, AwsS3Provider.class,
-        EmbeddedS3Config.class})
+@Import(value = {
+        MemberService.class,
+        MemberTestHelper.class,
+        PasswordEncryptor.class,
+        AwsS3Provider.class,
+        S3TestConfig.class
+})
 @ServiceTest
 class MemberServiceTest {
 

--- a/backend/src/test/java/kr/touroot/travelplan/helper/TravelPlanTestHelper.java
+++ b/backend/src/test/java/kr/touroot/travelplan/helper/TravelPlanTestHelper.java
@@ -71,7 +71,7 @@ public class TravelPlanTestHelper {
 
     public TravelPlan initTravelPlanTestData() {
         Member author = initMemberTestData();
-        TravelPlan travelPlan = getTravelPlan("여행계획", LocalDate.MAX, author);
+        TravelPlan travelPlan = getTravelPlan("여행계획", LocalDate.now().plusDays(2), author);
         TravelPlanDay travelPlanDay = getTravelPlanDay(0, travelPlan);
         TravelPlanPlace travelPlanPlace = getTravelPlanPlace(0, "장소", "37.5175896", "127.0867236", travelPlanDay, "KR");
         TravelPlaceTodo travelPlaceTodo = getTravelPlaceTodo(travelPlanPlace, "테스트짜기", 0, false);
@@ -85,7 +85,7 @@ public class TravelPlanTestHelper {
     }
 
     public TravelPlan initTravelPlanTestData(Member author) {
-        TravelPlan travelPlan = getTravelPlan("여행계획", LocalDate.MAX, author);
+        TravelPlan travelPlan = getTravelPlan("여행계획", LocalDate.now().plusDays(2), author);
         TravelPlanDay travelPlanDay = getTravelPlanDay(0, travelPlan);
         TravelPlanPlace travelPlanPlace = getTravelPlanPlace(0, "장소", "37.5175896", "127.0867236", travelPlanDay, "KR");
         TravelPlaceTodo travelPlaceTodo = getTravelPlaceTodo(travelPlanPlace, "테스트짜기", 0, false);

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -82,7 +82,7 @@ class TravelPlanFacadeServiceTest {
         PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
         PlanRequest request = PlanRequest.builder()
                 .title("신나는 한강 여행")
-                .startDate(LocalDate.MAX)
+                .startDate(LocalDate.now().plusDays(2))
                 .days(List.of(planDayRequest))
                 .build();
 
@@ -134,7 +134,7 @@ class TravelPlanFacadeServiceTest {
         PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
         PlanRequest request = PlanRequest.builder()
                 .title("수정된 한강 여행")
-                .startDate(LocalDate.MAX)
+                .startDate(LocalDate.now().plusDays(2))
                 .days(List.of(planDayRequest))
                 .build();
 

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanFacadeServiceTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import kr.touroot.authentication.infrastructure.PasswordEncryptor;
 import kr.touroot.global.ServiceTest;
 import kr.touroot.global.auth.dto.MemberAuth;
-import kr.touroot.global.config.EmbeddedS3Config;
+import kr.touroot.global.config.S3TestConfig;
 import kr.touroot.global.exception.BadRequestException;
 import kr.touroot.image.infrastructure.AwsS3Provider;
 import kr.touroot.member.domain.Member;
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Import;
         PasswordEncryptor.class,
         TravelPlanTestHelper.class,
         AwsS3Provider.class,
-        EmbeddedS3Config.class
+        S3TestConfig.class
 })
 @ServiceTest
 class TravelPlanFacadeServiceTest {

--- a/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelplan/service/TravelPlanServiceTest.java
@@ -152,7 +152,7 @@ class TravelPlanServiceTest {
         PlanDayRequest planDayRequest = new PlanDayRequest(List.of(planPlaceRequest));
         PlanRequest request = PlanRequest.builder()
                 .title("수정된 한강 여행")
-                .startDate(LocalDate.MAX)
+                .startDate(LocalDate.now().plusDays(2))
                 .days(List.of(planDayRequest))
                 .build();
 

--- a/backend/src/test/java/kr/touroot/utils/DatabaseCleaner.java
+++ b/backend/src/test/java/kr/touroot/utils/DatabaseCleaner.java
@@ -15,9 +15,9 @@ public class DatabaseCleaner {
     public static final String CAMEL_CASE = "([a-z])([A-Z])";
     public static final String SNAKE_CASE = "$1_$2";
     private static final String TRUNCATE_TABLE = "TRUNCATE TABLE %s";
-    private static final String ALTER_COLUMN_ID = "ALTER TABLE %s ALTER COLUMN id RESTART WITH 1";
-    public static final String INTEGRITY_FALSE = "SET REFERENTIAL_INTEGRITY FALSE";
-    public static final String INTEGRITY_TRUE = "SET REFERENTIAL_INTEGRITY TRUE";
+    private static final String ALTER_COLUMN_ID = "ALTER TABLE %s AUTO_INCREMENT = 1";
+    public static final String INTEGRITY_FALSE = "SET FOREIGN_KEY_CHECKS = 0";
+    public static final String INTEGRITY_TRUE = "SET FOREIGN_KEY_CHECKS = 1";
 
     @PersistenceContext
     private EntityManager entityManager;

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -23,6 +23,9 @@ cloud:
 server:
   port: 8081
 spring:
+  config:
+    activate:
+      on-profile: test
   flyway:
     enabled: true
   datasource:

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -15,8 +15,8 @@ security:
 cloud:
   aws:
     s3:
-      bucket: techcourse-project-2024
-      image-base-uri: https://dev.touroot.kr/
+      bucket: test-bucket
+      image-base-uri: https://test.touroot.kr/
       origin-storage-path: touroot/
       temporary-storage-path: temporary/
       image-storage-path: images/

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -24,7 +24,7 @@ server:
   port: 8081
 spring:
   flyway:
-    enabled: false
+    enabled: true
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8://test
@@ -34,13 +34,11 @@ spring:
       hibernate:
         format_sql: true
     hibernate:
-      ddl-auto: create
-    defer-datasource-initialization: true
+      ddl-auto: validate
     open-in-view: false
   sql:
     init:
       mode: never
-
 cors:
   allowed-origins: http://localhost:3000
 

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -26,11 +26,8 @@ spring:
   flyway:
     enabled: false
   datasource:
-    url: jdbc:h2:mem:test
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8://test
   jpa:
     show-sql: true
     properties:


### PR DESCRIPTION
# ✅ 작업 내용

- Test에서 사용되는 데이터베이스를 테스트컨테이너 MySQL 데이터베이스로 교체
- Test에서 사용되는 S3 스터빙 로직을 테스트컨테이너 기반의 실제 환경으로 교체
- 로컬 환경에서 Flyway Script를 체크할 수 있도록 flyway enable
- H2 문법으로 작성된 DBCleaner 객체 수정

# 🙈 참고 사항
- 테스트 돌릴 때 **개발자 로컬환경에 도커를 실행시킨 상태로 실행**해야 함 
- 현재 테스트 돌릴 때 운용하는 컨테이너는 MySQL 컨테이너와 S3 컨테이너 
- MySQL 컨테이너는 한번 띄우고 재사용되도록 Datasource 프로퍼티를 수정한 상태
- S3 컨테이너는 컴포넌트 스캔을 통해 빈이 구성될 때마다 Config를 통해 구성

테스트 컨테이너는 자바 코드레벨에서 컨테이너를 구성하고 컨테이너와의 협력을 통한 통합테스트를 가능하게 합니다. 궁금한 것이 있으시다면 코멘트로 질문 남겨주세요
