### PR TITLE
[Feature] - Redis cache 도입

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
     // QueryDSL

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.20.4"
     testImplementation "org.testcontainers:mysql"
     testImplementation 'org.testcontainers:localstack'
+    testImplementation 'com.redis:testcontainers-redis:2.2.2'
 
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/backend/src/main/java/kr/touroot/global/config/CacheConfig.java
+++ b/backend/src/main/java/kr/touroot/global/config/CacheConfig.java
@@ -1,4 +1,4 @@
-package kr.touroot.tag.cache;
+package kr.touroot.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;

--- a/backend/src/main/java/kr/touroot/tag/cache/CacheConfig.java
+++ b/backend/src/main/java/kr/touroot/tag/cache/CacheConfig.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -15,6 +16,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableCaching
 @Configuration
 public class CacheConfig {
 

--- a/backend/src/main/java/kr/touroot/tag/cache/CacheConfig.java
+++ b/backend/src/main/java/kr/touroot/tag/cache/CacheConfig.java
@@ -1,25 +1,52 @@
 package kr.touroot.tag.cache;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class CacheConfig {
 
     @Bean
-    public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("tag");
-        cacheManager.setCaffeine(caffeineConfig());
-
-        return cacheManager;
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(getRedisCacheConfiguration())
+                .build();
     }
 
-    private Caffeine<Object, Object> caffeineConfig() {
-        return Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofDays(1));
+    private RedisCacheConfiguration getRedisCacheConfiguration() {
+        SerializationPair<String> keySerializationPair = SerializationPair.fromSerializer(new StringRedisSerializer());
+        SerializationPair<Object> valueSerializationPair = SerializationPair.fromSerializer(
+                new GenericJackson2JsonRedisSerializer(getObjectMapperForRedisCacheManager())
+        );
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(keySerializationPair)
+                .serializeValuesWith(valueSerializationPair)
+                .entryTtl(Duration.ofHours(1L))
+                .disableCachingNullValues();
+    }
+
+    private ObjectMapper getObjectMapperForRedisCacheManager() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+                DefaultTyping.EVERYTHING
+        );
+
+        return objectMapper;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,6 +49,10 @@ server:
 ---
 # local profile
 spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
   flyway:
     enabled: false
   config:
@@ -89,6 +93,11 @@ cloud:
 ---
 # dev profile
 spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   flyway:
     enabled: true
     baseline-version: 1
@@ -145,6 +154,10 @@ loki:
 ---
 # prod profile
 spring:
+  data:
+    redis:
+      host: ENC(otCSAgc44Iy/31eLWwIb/WjJwH8YAjfQ)
+      port: 6379
   flyway:
     enabled: true
     baseline-version: 1

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -97,7 +97,6 @@ spring:
     redis:
       host: localhost
       port: 6379
-
   flyway:
     enabled: true
     baseline-version: 1

--- a/backend/src/test/java/kr/touroot/global/AbstractIntegrationTest.java
+++ b/backend/src/test/java/kr/touroot/global/AbstractIntegrationTest.java
@@ -1,5 +1,6 @@
 package kr.touroot.global;
 
+import com.redis.testcontainers.RedisContainer;
 import java.io.IOException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -16,18 +17,22 @@ public abstract class AbstractIntegrationTest {
 
     private static final DockerImageName MYSQL_IMAGE_NAME = DockerImageName.parse("mysql:8");
     private static final DockerImageName LOCALSTACK_IMAGE_NAME = DockerImageName.parse("localstack/localstack");
+    private static final DockerImageName REDIS_IMAGE_NAME = DockerImageName.parse("redis:7.4.1");
+
     private static final String S3_BUCKET_NAME = "test-bucket";
 
     private static final MySQLContainer<?> mySQLContainer;
     private static final LocalStackContainer localStackContainer;
+    private static final RedisContainer redisContainer;
 
     static {
         mySQLContainer = new MySQLContainer<>(MYSQL_IMAGE_NAME);
         localStackContainer = new LocalStackContainer(LOCALSTACK_IMAGE_NAME).withServices(Service.S3);
+        redisContainer = new RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME.withTag(RedisContainer.DEFAULT_TAG));
 
         mySQLContainer.start();
         localStackContainer.start();
-
+        redisContainer.start();
         createS3Bucket();
     }
 
@@ -51,5 +56,9 @@ public abstract class AbstractIntegrationTest {
         registry.add("cloud.aws.s3.access-key", localStackContainer::getAccessKey);
         registry.add("cloud.aws.s3.secret-key", localStackContainer::getSecretKey);
         registry.add("cloud.aws.s3.endpoint", () -> localStackContainer.getEndpointOverride(Service.S3));
+
+        // add Redis Properties
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
     }
 }


### PR DESCRIPTION
# ✅ 작업 내용

- application.yml에 Redis 연결 정보 추가
- Redis Config 작성
- CacheManager Redis로 변경
- Testcontainers Redis 추가

# 🙈 참고 사항
S3처럼 local에서 EmbeddedRedis를 사용할까 했는데 다음을 이유로 그러지 않기로 했습니다.
- 공식 라이브러리가 아닌 개인 소유의 라이브러리를 사용해야 함 (신뢰성 낮음)
- 라이브러리 노후화 (최신 업데이트가 6년전 ㄷㄷ redis 2.X 버전까지만 기능 업데이트)
- 불친절한 예외 메시지등 낮은 사용성

우선은 local 프로파일로 서버를 돌려보고 싶으시다면 redis를 실행하고 사용하시면 됩니다~
테스트의 경우에는Testcontainers를 통한 통합테스트 추상 클래스에 redis 컨테이너를 추가했으니 신경쓰지 않으셔도 됩니다.