### PR TITLE
[Feature] - 모니터링/로깅 시스템 통합

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -21,9 +21,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Make keystore file
-        run: echo "${{secrets.SSL_KEYSTORE}}" | base64 --decode > ./src/main/resources/keystore.p12
-
       - name: Gradle Caching
         uses: actions/cache@v3
         with:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -201,4 +201,4 @@ cloud:
       origin-storage-path: touroot/
 
 loki:
-  loki-url: ENC(FHJkwYBoGIuSifQd/92GjnWRS1nvcil2CPFCcWbTicu4rMe/gyFRYzQeqAMCyPkr)
+  loki-url: ENC(JTagwgNAOqA2l2uOvQQHzQAkmSPLUUDSdloHQp3QIIa9Z9zyTrtcHpdQfwPzjBqC)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -124,12 +124,6 @@ spring:
     hibernate:
       ddl-auto: validate
 
-server:
-  ssl:
-    key-store-type: PKCS12
-    key-store-password: ENC(faQYah2QoIaNVRZD9J6/junPRWkc5gaiAs+mEbxDk+I=)
-    key-store: ENC(7VQCNdI7mXATwc4AiymZoyf3mz9SiskXpLnenpMSFBI=)
-
 security:
   jwt:
     token:


### PR DESCRIPTION
# ✅ 작업 내용
- 프로덕션에 대한 모니터링 및 로깅 수집을 dev 서버로 통합
- 그라파나, 프로메테우스, 로키를 통합해서 하나만 사용하도록 변경
- 로키에서 로그 수집 시 호스트네임을 통해 prod와 dev 를 구분하도로록 설정
- 443 포트 하나로 dev와 그라파나를 포워딩 하도록 ngnix 구축
- dev 프로파일 톰캣에서 ssl 제거

# 🙈 참고 사항
그라파나, 프로메테우스, 로키를 2개로 쪼개서 관리할 필요가 없다고 느껴져 하나로 통합하였습니다.
그라파나에서 각각을 따로 보게 하려면 조금 더 설정을 해야합니다.

dev 프로파일에서 ssl 을 제거하였습니다.
ngnix에서 ssl termination 을 하도록 설정하고, 서브 도메인(`api-dev`, `grafana`) 에 따라 프록시 패스를 하도록 설정하였습니다.

이전 데이터까지 옮기고 약간의 설정만 더 하면 끝나지만, PR 먼저 오픈합니다.
현재 그라파나에서 prod/dev 로그가 섞여있는데, 설정을 통해 분리할 예정이니 참고해주세요.

코드와 관련된 부분은 추가 수정이 없을 것 같으니 확인해 주시면 감사하겠습니다.