### PR TITLE
[Feature] - 인기 여행기 페이징 응답 캐싱 무효화 전략 개선

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
+++ b/backend/src/main/java/kr/touroot/travelogue/domain/Travelogue.java
@@ -121,6 +121,10 @@ public class Travelogue extends BaseEntity {
         travelogueDays.forEach(this::addDay);
     }
 
+    public boolean isLikeCountBiggerThan(long targetLikeCount) {
+        return likeCount > targetLikeCount;
+    }
+
     public void increaseLikeCount() {
         likeCount += LIKE_COUNT_WEIGHT;
     }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepository.java
@@ -1,0 +1,6 @@
+package kr.touroot.travelogue.repository.query;
+
+public interface TravelogueLikeQueryRepository {
+
+    int countTravelougeLikeByRank(int rank);
+}

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepository.java
@@ -2,5 +2,5 @@ package kr.touroot.travelogue.repository.query;
 
 public interface TravelogueLikeQueryRepository {
 
-    int countTravelougeLikeByRank(int rank);
+    long countTravelougeLikeByRank(int rank);
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package kr.touroot.travelogue.repository.query;
 import static kr.touroot.travelogue.domain.QTravelogueLike.travelogueLike;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,7 +15,7 @@ public class TravelogueLikeQueryRepositoryImpl implements TravelogueLikeQueryRep
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public int countTravelougeLikeByRank(int rank) {
+    public long countTravelougeLikeByRank(int rank) {
         Long likeCount = jpaQueryFactory.select(travelogueLike.count())
                 .from(travelogueLike)
                 .groupBy(travelogueLike.travelogue.id)
@@ -22,9 +23,7 @@ public class TravelogueLikeQueryRepositoryImpl implements TravelogueLikeQueryRep
                 .offset(rank - 1L)
                 .limit(1)
                 .fetchOne();
-        if (likeCount == null) {
-            return 0;
-        }
-        return likeCount.intValue();
+
+        return Optional.ofNullable(likeCount).orElse(0L);
     }
 }

--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package kr.touroot.travelogue.repository.query;
+
+import static kr.touroot.travelogue.domain.QTravelogueLike.travelogueLike;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+
+@RequiredArgsConstructor
+@Repository
+public class TravelogueLikeQueryRepositoryImpl implements TravelogueLikeQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public int countTravelougeLikeByRank(int rank) {
+        Long likeCount = jpaQueryFactory.select(travelogueLike.count())
+                .from(travelogueLike)
+                .groupBy(travelogueLike.travelogue.id)
+                .orderBy(travelogueLike.count().desc())
+                .offset(rank - 1L)
+                .limit(1)
+                .fetchOne();
+        if (likeCount == null) {
+            return 0;
+        }
+        return likeCount.intValue();
+    }
+}

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TravelogueFacadeService {
 
     public static final int MAX_CACHING_PAGE = 4;
+    public static final String TRAVELOGUE_PAGE_CACHE_NAME = "traveloguePage";
 
     private final TravelogueService travelogueService;
     private final TravelogueImagePerpetuationService travelogueImagePerpetuationService;
@@ -68,7 +69,7 @@ public class TravelogueFacadeService {
     }
 
     @Cacheable(
-            cacheNames = "traveloguePage",
+            cacheNames = TRAVELOGUE_PAGE_CACHE_NAME,
             key = "#pageable",
             condition = "#pageable.pageNumber <= " + MAX_CACHING_PAGE + " && " +
                     "#filterRequest.toFilterCondition().emptyCondition && " +
@@ -156,7 +157,7 @@ public class TravelogueFacadeService {
     }
 
     private void invalidateTraveloguePageCache() {
-        Cache cache = cacheManager.getCache("traveloguePage");
+        Cache cache = cacheManager.getCache(TRAVELOGUE_PAGE_CACHE_NAME);
         if (cache != null) {
             cache.clear();
         }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -122,7 +122,7 @@ public class TravelogueFacadeService {
         Member author = memberService.getMemberById(member.memberId());
         Travelogue travelogue = travelogueService.getTravelogueById(id);
 
-        processTraveloguePageCache(travelogue);
+        evictTraveloguePageCacheIfAffected(travelogue);
         travelogueTagService.deleteAllByTravelogue(travelogue);
         travelogueLikeService.deleteAllByTravelogue(travelogue);
         travelogueCountryService.deleteAllByTravelogue(travelogue);
@@ -134,7 +134,7 @@ public class TravelogueFacadeService {
         Travelogue travelogue = travelogueService.getTravelogueById(travelogueId);
         Member liker = memberService.getMemberById(member.memberId());
         travelogueLikeService.likeTravelogue(travelogue, liker);
-        processTraveloguePageCache(travelogue);
+        evictTraveloguePageCacheIfAffected(travelogue);
 
         return new TravelogueLikeResponse(true, travelogue.getLikeCount());
     }
@@ -142,14 +142,14 @@ public class TravelogueFacadeService {
     @Transactional
     public TravelogueLikeResponse unlikeTravelogue(Long travelogueId, MemberAuth member) {
         Travelogue travelogue = travelogueService.getTravelogueById(travelogueId);
-        processTraveloguePageCache(travelogue);
+        evictTraveloguePageCacheIfAffected(travelogue);
         Member liker = memberService.getMemberById(member.memberId());
         travelogueLikeService.unlikeTravelogue(travelogue, liker);
 
         return new TravelogueLikeResponse(false, travelogue.getLikeCount());
     }
 
-    private void processTraveloguePageCache(Travelogue travelogue) {
+    private void evictTraveloguePageCacheIfAffected(Travelogue travelogue) {
         long minimumLikeCountForCacheEviction = travelogueLikeService.getMinimumLikeCountForCacheEviction();
         if (travelogue.isLikeCountBiggerThan(minimumLikeCountForCacheEviction)) {
             invalidateTraveloguePageCache();

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -26,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TravelogueFacadeService {
 
+    public static final int MAX_CACHING_PAGE = 4;
+
     private final TravelogueService travelogueService;
     private final TravelogueImagePerpetuationService travelogueImagePerpetuationService;
     private final TravelogueTagService travelogueTagService;
@@ -65,7 +67,7 @@ public class TravelogueFacadeService {
     @Cacheable(
             cacheNames = "traveloguePage",
             key = "#pageable",
-            condition = "#pageable.pageNumber <= 4 && " +
+            condition = "#pageable.pageNumber <= " + MAX_CACHING_PAGE + " && " +
                     "#filterRequest.toFilterCondition().emptyCondition && " +
                     "#searchRequest.toSearchCondition().emptyCondition && " +
                     "#pageable.sort.toString() == 'likeCount: DESC'"

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueFacadeService.java
@@ -65,7 +65,10 @@ public class TravelogueFacadeService {
     @Cacheable(
             cacheNames = "traveloguePage",
             key = "#pageable",
-            condition = "#pageable.pageNumber <= 4 && #filterRequest.toFilterCondition().emptyCondition && #searchRequest.toSearchCondition().emptyCondition"
+            condition = "#pageable.pageNumber <= 4 && " +
+                    "#filterRequest.toFilterCondition().emptyCondition && " +
+                    "#searchRequest.toSearchCondition().emptyCondition && " +
+                    "#pageable.sort.toString() == 'likeCount: DESC'"
     )
     @Transactional(readOnly = true)
     public Page<TravelogueSimpleResponse> findSimpleTravelogues(

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -1,7 +1,5 @@
 package kr.touroot.travelogue.service;
 
-import static kr.touroot.travelogue.service.TravelogueFacadeService.MAX_CACHING_PAGE;
-
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueLike;
@@ -17,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TravelogueLikeService {
 
-    private static final int CACHE_EVICTION_LIKE_RANK = MAX_CACHING_PAGE * 5;
+    private static final int CACHE_EVICTION_LIKE_RANK = TravelogueFacadeService.MAX_CACHING_PAGE * 5;
 
     private final TravelogueLikeRepository travelogueLikeRepository;
     private final TravelogueLikeQueryRepository travelogueLikeQueryRepository;

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeService.java
@@ -1,9 +1,12 @@
 package kr.touroot.travelogue.service;
 
+import static kr.touroot.travelogue.service.TravelogueFacadeService.MAX_CACHING_PAGE;
+
 import kr.touroot.member.domain.Member;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueLike;
 import kr.touroot.travelogue.repository.TravelogueLikeRepository;
+import kr.touroot.travelogue.repository.query.TravelogueLikeQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TravelogueLikeService {
 
+    private static final int CACHE_EVICTION_LIKE_RANK = MAX_CACHING_PAGE * 5;
+
     private final TravelogueLikeRepository travelogueLikeRepository;
+    private final TravelogueLikeQueryRepository travelogueLikeQueryRepository;
 
     @Transactional(readOnly = true)
     public Page<TravelogueLike> findByLiker(Member liker, Pageable pageable) {
@@ -48,5 +54,9 @@ public class TravelogueLikeService {
     @Transactional
     public void deleteAllByTravelogue(Travelogue travelogue) {
         travelogueLikeRepository.deleteAllByTravelogue(travelogue);
+    }
+
+    public long getMinimumLikeCountForCacheEviction() {
+        return travelogueLikeQueryRepository.countTravelougeLikeByRank(CACHE_EVICTION_LIKE_RANK);
     }
 }

--- a/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
+++ b/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
@@ -1,13 +1,23 @@
 package kr.touroot.global;
 
 import kr.touroot.global.config.TestQueryDslConfig;
+import kr.touroot.utils.DatabaseCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(TestQueryDslConfig.class)
+@Import({TestQueryDslConfig.class, DatabaseCleaner.class})
 public abstract class AbstractRepositoryIntegrationTest extends AbstractIntegrationTest {
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    protected void baseSetUp() {
+        databaseCleaner.executeTruncate();
+    }
 }

--- a/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
+++ b/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
@@ -1,0 +1,13 @@
+package kr.touroot.global;
+
+import kr.touroot.global.config.TestQueryDslConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestQueryDslConfig.class)
+public abstract class AbstractRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+}

--- a/backend/src/test/java/kr/touroot/global/config/TestQueryDslConfig.java
+++ b/backend/src/test/java/kr/touroot/global/config/TestQueryDslConfig.java
@@ -3,6 +3,8 @@ package kr.touroot.global.config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import kr.touroot.travelogue.repository.query.TravelogueLikeQueryRepository;
+import kr.touroot.travelogue.repository.query.TravelogueLikeQueryRepositoryImpl;
 import kr.touroot.travelogue.repository.query.TravelogueQueryRepository;
 import kr.touroot.travelogue.repository.query.TravelogueQueryRepositoryImpl;
 import kr.touroot.travelogue.repository.query.TravelogueTagQueryRepository;
@@ -38,5 +40,10 @@ public class TestQueryDslConfig {
     @Bean
     public PlaceTodoQueryRepository placeTodoQueryRepository() {
         return new PlaceTodoQueryRepositoryImpl(jpaQueryFactory());
+    }
+
+    @Bean
+    public TravelogueLikeQueryRepository travelogueLikeQueryRepository() {
+        return new TravelogueLikeQueryRepositoryImpl(jpaQueryFactory());
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepositoryImplTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/repository/query/TravelogueLikeQueryRepositoryImplTest.java
@@ -1,0 +1,51 @@
+package kr.touroot.travelogue.repository.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.touroot.global.AbstractRepositoryIntegrationTest;
+import kr.touroot.member.domain.Member;
+import kr.touroot.member.fixture.MemberFixture;
+import kr.touroot.member.repository.MemberRepository;
+import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.domain.TravelogueLike;
+import kr.touroot.travelogue.fixture.TravelogueFixture;
+import kr.touroot.travelogue.repository.TravelogueLikeRepository;
+import kr.touroot.travelogue.repository.TravelogueRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("TravelogueLikeQueryRepositoryImpl 테스트")
+class TravelogueLikeQueryRepositoryImplTest extends AbstractRepositoryIntegrationTest {
+
+    @Autowired
+    private TravelogueLikeQueryRepository travelogueLikeQueryRepository;
+    @Autowired
+    private TravelogueLikeRepository travelogueLikeRepository;
+    @Autowired
+    private TravelogueRepository travelogueRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("좋아요 수가 특정 순위에 해당하는 게시물의 좋아요 개수를 반환한다.")
+    @Test
+    void countTravelougeLikeByRank() {
+        // given
+        Member member = MemberFixture.KAKAO_MEMBER.getMember();
+        memberRepository.save(member);
+
+        Travelogue likedTravelogue = TravelogueFixture.JEJU_TRAVELOGUE.getTravelogueOwnedBy(member);
+        Travelogue unlikedTravelogue = TravelogueFixture.JEJU_TRAVELOGUE.getTravelogueOwnedBy(member);
+        travelogueRepository.save(likedTravelogue);
+        travelogueRepository.save(unlikedTravelogue);
+
+        travelogueLikeRepository.save(new TravelogueLike(likedTravelogue, member));
+        // when & then
+        Assertions.assertAll(
+                () -> assertThat(travelogueLikeQueryRepository.countTravelougeLikeByRank(1)).isOne(),
+                () -> assertThat(travelogueLikeQueryRepository.countTravelougeLikeByRank(2)).isZero(),
+                () -> assertThat(travelogueLikeQueryRepository.countTravelougeLikeByRank(20)).isZero()
+        );
+    }
+}

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -133,7 +133,7 @@ class TravelogueFacadeServiceTest extends AbstractServiceIntegrationTest {
         // given
         TravelogueSearchRequest searchRequest = new TravelogueSearchRequest(null, null);
         TravelogueFilterRequest filterRequest = new TravelogueFilterRequest(null, null);
-        Pageable pageRequest = PageRequest.of(pageNumber, 5, Sort.by("id"));
+        Pageable pageRequest = PageRequest.of(pageNumber, 5, Sort.by("likeCount").descending());
 
         // when
         service.findSimpleTravelogues(filterRequest, searchRequest, pageRequest);
@@ -202,7 +202,7 @@ class TravelogueFacadeServiceTest extends AbstractServiceIntegrationTest {
         // given
         TravelogueSearchRequest searchRequest = new TravelogueSearchRequest(null, null);
         TravelogueFilterRequest filterRequest = new TravelogueFilterRequest(null, null);
-        Pageable pageRequest = PageRequest.of(1, 5, Sort.by("id"));
+        Pageable pageRequest = PageRequest.of(1, 5, Sort.by("likeCount").descending());
 
         // when
         service.findSimpleTravelogues(filterRequest, searchRequest, pageRequest);

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueFacadeServiceTest.java
@@ -432,6 +432,7 @@ class TravelogueFacadeServiceTest extends AbstractServiceIntegrationTest {
         Member liker = testHelper.initKakaoMemberTestData();
         Travelogue travelogue = testHelper.initTravelogueTestDataWithLike(liker);
         redisTemplate.opsForValue().set("traveloguePage::1", "cached");
+
         // when
         service.likeTravelogue(travelogue.getId(), new MemberAuth(liker.getId()));
 


### PR DESCRIPTION
# ✅ 작업 내용

- [x] 좋아요 수 변경, 여행기 삭제 등 상위 4개의 페이지 컨텐츠 변경 시 캐시 무효화

# 🙈 참고 사항
https://github.com/woowacourse-teams/2024-touroot/issues/643

임계치의 좋아요 개수를 계산하고 해당 값보다 높은 여행기의 좋아요수가 수정될 경우 page 캐시를 무효화하도록 로직을 작성했습니다.
SpEL에서 프록시의 실 객체 인스턴스 메서드를 참조하는 데에 어려움이 있어 캐시를 process하는 과정을 FacadeService에 위치시켰습니다.