### PR TITLE
[Fix] - 서로 다른 테이블에 중복 저장되는 여행기 좋아요 정보 궁극적 일관성 확보

### DIFF
--- a/backend/src/main/java/kr/touroot/global/config/SchedulingConfig.java
+++ b/backend/src/main/java/kr/touroot/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package kr.touroot.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueRepository.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/TravelogueRepository.java
@@ -5,8 +5,19 @@ import kr.touroot.travelogue.domain.Travelogue;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface TravelogueRepository extends JpaRepository<Travelogue, Long> {
 
     Page<Travelogue> findAllByAuthor(Member author, Pageable pageable);
+
+    @Modifying
+    @Transactional
+    @Query("""
+             UPDATE Travelogue t
+             SET t.likeCount = (SELECT COUNT(*) FROM TravelogueLike l WHERE l.travelogue.id = t.id)
+            """)
+    void syncLikeCounts();
 }

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeSyncService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeSyncService.java
@@ -1,0 +1,27 @@
+package kr.touroot.travelogue.service;
+
+import kr.touroot.travelogue.repository.TravelogueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TravelogueLikeSyncService {
+
+    private final TravelogueRepository travelogueRepository;
+
+    /**
+     * 매주 월요일 오전 3시에 좋아요 개수를 동기화
+     */
+    @Scheduled(cron = "0 0 3 * * MON")
+    @Transactional
+    public void syncLikeCountsWeekly() {
+        log.info("Starting weekly like count sync...");
+        travelogueRepository.syncLikeCounts();
+        log.info("Weekly like count sync completed.");
+    }
+}

--- a/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
+++ b/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
@@ -7,8 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({TestQueryDslConfig.class, DatabaseCleaner.class})
 public abstract class AbstractRepositoryIntegrationTest extends AbstractIntegrationTest {

--- a/backend/src/test/java/kr/touroot/travelogue/repository/TravelogueRepositoryTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/repository/TravelogueRepositoryTest.java
@@ -1,0 +1,45 @@
+package kr.touroot.travelogue.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import kr.touroot.global.AbstractRepositoryIntegrationTest;
+import kr.touroot.member.domain.Member;
+import kr.touroot.member.fixture.MemberFixture;
+import kr.touroot.member.repository.MemberRepository;
+import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.domain.TravelogueLike;
+import kr.touroot.travelogue.fixture.TravelogueFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TravelogueRepositoryTest extends AbstractRepositoryIntegrationTest {
+
+    @Autowired
+    private TravelogueLikeRepository travelogueLikeRepository;
+    @Autowired
+    private TravelogueRepository travelogueRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("실제 좋아요 정보와 여행기에 저장된 좋아요 개수를 동기화한다")
+    @Test
+    void synchronizeTravelogueLikeCount() {
+        // given
+        Member travelogueOwner = MemberFixture.KAKAO_MEMBER.getMember();
+        Member liker = MemberFixture.TOUROOT_LOCAL_USER.getMember();
+        memberRepository.save(travelogueOwner);
+        memberRepository.save(liker);
+
+        Travelogue travelogue = TravelogueFixture.JEJU_TRAVELOGUE.getTravelogueOwnedBy(travelogueOwner);
+        travelogueRepository.save(travelogue);
+
+        travelogueLikeRepository.save(new TravelogueLike(travelogue, liker));
+
+        // when
+        travelogueRepository.syncLikeCounts();
+
+        // then
+        assertThat(travelogueRepository.findById(travelogue.getId()).get().getLikeCount()).isOne();
+    }
+}


### PR DESCRIPTION
# ✅ 작업 내용

- [x] Sync Schedule을 활용한 좋아요 개수 궁극적 일관성 확보

# 🙈 참고 사항
다양한 방식이 있었지만 좋아요 충돌이 자주 일어나지 않는 현재 상황과 성능을 고려하여 배치 작업을 스케줄링하였습니다.
트래픽이 가장 적은 월요일 오전 3시 마다 여행기 좋아요 개수를 동기화하도록 설정하였습니다. 
현재 정의된 작업은 모든 여행기를 순회하며 일관성을 맞추는 작업을 수행합니다.
포스팅의 개수가 아직 많지 않아 이정도로 처리해도 성능에 크게 문제가 없는 것을 확인했는데, 후에 포스팅이 많아지면 modifiedAt을 활용하고 배치 단위 설정 및 병렬 처리를 고려해볼 수 있을 듯 합니다.

아직까지는 그 정도의 확장성을 고려하기 과하다 생각하여 현재수준으로 작업 마치고 PR올립니다.

https://github.com/woowacourse-teams/2024-touroot/issues/650
