### PR TITLE
[Feature] - 태그 필터링 쿼리 개선

### DIFF
--- a/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
+++ b/backend/src/main/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImpl.java
@@ -2,7 +2,6 @@ package kr.touroot.travelogue.repository.query;
 
 import static kr.touroot.travelogue.domain.QTravelogue.travelogue;
 import static kr.touroot.travelogue.domain.QTravelogueCountry.travelogueCountry;
-import static kr.touroot.travelogue.domain.QTravelogueTag.travelogueTag;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -11,6 +10,7 @@ import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import kr.touroot.travelogue.domain.QTravelogueTag;
 import kr.touroot.travelogue.domain.Travelogue;
 import kr.touroot.travelogue.domain.TravelogueFilterCondition;
 import kr.touroot.travelogue.domain.search.CountryCode;
@@ -95,12 +95,15 @@ public class TravelogueQueryRepositoryImpl implements TravelogueQueryRepository 
             return;
         }
 
-        List<Long> tags = filter.getTag();
+        List<Long> tagIds = filter.getTag();
+        tagIds.forEach(tagId -> joinTravelogueTag(query, tagId));
+    }
 
-        query.join(travelogueTag).on(travelogueTag.travelogue.eq(travelogue))
-                .where(travelogueTag.tag.id.in(tags))
-                .groupBy(travelogue)
-                .having(travelogueTag.count().eq(Long.valueOf(tags.size())));
+    private void joinTravelogueTag(JPAQuery<Travelogue> query, Long tagId) {
+        QTravelogueTag travelogueTag = new QTravelogueTag("travelogueTag" + tagId);
+        query.join(travelogueTag)
+                .on(travelogueTag.travelogue.eq(travelogue)
+                        .and(travelogueTag.tag.id.eq(tagId)));
     }
 
     public void addPeriodFilter(JPAQuery<Travelogue> query, TravelogueFilterCondition filter) {

--- a/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
+++ b/backend/src/test/java/kr/touroot/global/AbstractRepositoryIntegrationTest.java
@@ -1,6 +1,7 @@
 package kr.touroot.global;
 
 import kr.touroot.global.config.TestQueryDslConfig;
+import kr.touroot.travelogue.helper.TravelogueTestHelper;
 import kr.touroot.utils.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DataJpaTest
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({TestQueryDslConfig.class, DatabaseCleaner.class})
+@Import({TestQueryDslConfig.class, DatabaseCleaner.class, TravelogueTestHelper.class})
 public abstract class AbstractRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImplTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/repository/query/TravelogueQueryRepositoryImplTest.java
@@ -1,0 +1,47 @@
+package kr.touroot.travelogue.repository.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import kr.touroot.global.AbstractRepositoryIntegrationTest;
+import kr.touroot.tag.domain.Tag;
+import kr.touroot.tag.fixture.TagFixture;
+import kr.touroot.travelogue.domain.Travelogue;
+import kr.touroot.travelogue.domain.TravelogueFilterCondition;
+import kr.touroot.travelogue.domain.search.SearchCondition;
+import kr.touroot.travelogue.helper.TravelogueTestHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+@DisplayName("TravelogueQueryRepositoryImpl 테스트")
+class TravelogueQueryRepositoryImplTest extends AbstractRepositoryIntegrationTest {
+
+    @Autowired
+    private TravelogueQueryRepository travelogueQueryRepository;
+    @Autowired
+    private TravelogueTestHelper testHelper;
+
+    @DisplayName("필터링된 여행기 목록을 조회한다.")
+    @Test
+    void filterTravelogues() {
+        // given
+        Tag tag1 = testHelper.initTagTestData(TagFixture.TAG_1.get());
+        Tag tag2 = testHelper.initTagTestData(TagFixture.TAG_2.get());
+        testHelper.initAllTravelogueTestData(List.of(tag1, tag2));
+        PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("like_count").descending());
+        TravelogueFilterCondition filterCondition = new TravelogueFilterCondition(List.of(1L, 2L), null);
+        SearchCondition searchCondition = new SearchCondition(null, null);
+
+        // when
+        Page<Travelogue> result =
+                travelogueQueryRepository.findAllByCondition(searchCondition, filterCondition, pageRequest);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+    }
+
+}


### PR DESCRIPTION
# ✅ 작업 내용

- 여행기 목록 조회 시 태그 필터링 후 좋아요 숫자로 정렬하는 쿼리를 개선하였습니다.

# 🙈 참고 사항
<details>
<summary>기존 쿼리</summary>

```sql
SELECT
    t1_0.id,
    t1_0.author_id,
    t1_0.created_at,
    t1_0.deleted_at,
    t1_0.like_count,
    t1_0.modified_at,
    t1_0.thumbnail,
    t1_0.title
FROM
    travelogue t1_0
        JOIN
    travelogue_tag tt1_0
    ON tt1_0.travelogue_id = t1_0.id
WHERE
    t1_0.deleted_at IS NULL
  AND tt1_0.tag_id IN (2, 3, 15)
GROUP BY
    t1_0.id
HAVING
    COUNT(tt1_0.id) = 3
ORDER BY
    t1_0.like_count DESC
LIMIT 5 OFFSET 0;
```
</details>

쿼리 성능 저하의 주요 원인은 JOIN 후 GROUP BY를 수행하기 때문입니다.

MySQL의 Nested Loop Join에서는 드라이빙 테이블의 크기가 JOIN 성능에 큰 영향을 미칩니다.
즉, JOIN 후 GROUP BY를 하면 LIMIT을 사용하더라도 전체 travelogue 테이블을 스캔해야 하므로 성능이 저하됩니다. 전체 결과가 나와야 집계가 가능하기 때문입니다.
따라서 like_count 인덱스를 활용해 정렬하더라도, 결국 travelogue의 모든 행을 조회해야 하므로 성능 저하가 발생합니다.

## 개선 방향
이를 해결하기 위해 GROUP BY 후 JOIN을 수행하도록 튜닝하면 성능이 크게 개선됩니다.
이렇게 하면 LIMIT 개수가 나올때 까지만 travelogue 행들을 조회하면 되므로, 드라이빙 테이블의 크기가 줄어들고 성능이 향상됩니다.
<details>
<summary>첫번째 개선 된 쿼리</summary>

```sql
SELECT t.id,
       t.author_id,
       t.created_at,
       t.deleted_at,
       t.like_count,
       t.modified_at,
       t.thumbnail,
       t.title
FROM travelogue t
         JOIN
     (SELECT tt.travelogue_id
      FROM travelogue_tag AS tt
      WHERE tt.tag_id IN (2, 3, 15)
      GROUP BY tt.travelogue_id
      HAVING COUNT(tt.id) = 3) ttt
     ON t.id = ttt.travelogue_id
WHERE t.deleted_at IS NULL
ORDER BY t.like_count DESC
LIMIT 5 OFFSET 0;
```
</details>

## OFFSET 증가에 따른 성능 저하
그러나 OFFSET이 커질수록 쿼리 성능은 다시 저하됩니다.
OFFSET이 증가하면 조회해야 할 travelogue의 행 수가 많아지면서 드라이빙 테이블의 크기가 커지고, JOIN 성능이 다시 저하되기 때문입니다.

## 드라이빙 테이블 선택 전략
- OFFSET이 작은 경우:
    - like_count 인덱스를 활용하여 travelogue를 정렬하는 것이 더 빠릅니다.
- OFFSET이 큰 경우:
    - 필터링된 travelogue_tag를 드라이빙 테이블로 삼고, travelogue와 JOIN한 후 직접 정렬(using filesort, using temporary)하는 것이 더 효율적입니다. 즉 like_count 인덱스를 활용하여 정렬하는 것보다 오히려 빠릅니다.
    - 이유는 필터링된 travelogue_tag의 행 수가 적어 드라이빙 테이블 크기가 줄어들고, 결과적으로 JOIN 부담이 감소하기 때문입니다.
- 최종 결정
    - 현재는 옵티마이저에게 드라이빙 테이블 선택을 맡기기로 결정했습니다.

실제 사용자 데이터는 특정 태그에 여행기가 몰리는 등 테스트 데이터와 다른 양상을 보일 가능성이 있습니다.
또한 OFFSET이 큰 쿼리가 발생할 가능성이 낮기도 하구요.
따라서 우선은 옵티마이저에게 드라이빙 테이블 선정을 맡기기로 결정하였습니다.

만약 OFFSET이 큰 쿼리에서 옵티마이저가 계속 like_count를 드라이빙 테이블로 선택해 성능이 저하된다면,
그때 가서 STRAIGHT_JOIN을 활용해 드라이빙 테이블을 명시적으로 지정하는 방식으로 최적화할 수 있습니다.

## 서브쿼리 개선 : GROUP BY 대신 다중 JOIN
이번에는 서브쿼리를 개선합니다.
GROUP BY와 HAVING 절을 통한 COUNT 쿼리가 동작하는 방식을 살펴보면 대략 다음과 같습니다.
1. 먼저 (tag_id, travelogue_id) 인덱스를 활용해 태그로 필터링을 먼저합니다.
2. 그 후 travelogue_id 로 집계를 합니다.
3. 같은 travelogue_id 에 대해 row 개수를 COUNT 합니다.

여기서 (tag_id, travelogue_id) 인덱스를 활용하더라고 travelogue_id 가 tag_id 마다 분산되어 있기때문에 인덱스를 제대로 활용하기 어려워집니다.
(순차 탐색이 어려워집니다.)

따라서 위의 쿼리를 travleogue_tag 와 여러 번 JOIN 하는 방식으로 개선하였습니다.

<details>
<summary>개선 된 서브 쿼리</summary>

```sql
SELECT tt1.travelogue_id
        FROM travelogue_tag tt1 JOIN travelogue_tag tt2
        ON tt1.travelog_id = tt2.travelogue_id
        WHERE tt1.tag_id = 2 AND tt2.tag_id = 3
```
</details>
이렇게하면 (tag_id, travelogue_id) 와 (travelogue_id, tag_id) 인덱스에 대해 커버링 인덱스만 발생하게 되어 개선이 됩니다.

이 때 태그 개수만큼 JOIN이 발생하게 되는데, 저희 서비스에서 최대 3개의 태그만 사용 가능하기 때문에 JOIN도 최대 3번까지만 일어나게 됩니다.

또한 위의 두 인덱스는 기존 FK 인덱스를 대체하기 때문에 추가적으로 인덱스를 거는 것이 아니기 때문에 WRITE 에 대한 연산에 손해가 발생하지 않습니다.

결론적으로는 서브쿼리도 사용하지 않고 travelogue 와 travelogue 여러 개를 직접 JOIN 하는 방식을 택하였습니다.
<details>
<summary>최종 개선 된 쿼리</summary>

```sql
SELECT
    t.id,
    t.author_id,
    t.created_at,
    t.deleted_at,
    t.like_count,
    t.modified_at,
    t.thumbnail,
    t.title
FROM
    travelogue t
JOIN
    travelogue_tag tt1 ON tt1.travelogue_id = t.id AND tt1.tag_id = 2
JOIN
    travelogue_tag tt2 ON tt2.travelogue_id = t.id AND tt2.tag_id = 3
JOIN
    travelogue_tag tt3 ON tt3.travelogue_id = t.id AND tt3.tag_id = 15
WHERE
    t.deleted_at IS NULL
ORDER BY
    t.like_count DESC
LIMIT 5 OFFSET 0;
```
</details>

가장 성능이 좋고, 쿼리의 가독성도 가장 좋다고 생각했기 때문입니다.

## 쿼리 개선 결과
결론적으로 travlogue 100만 개, 평균 좋아요 개수 50개 기준 다음과 같이 개선되었습니다.
- 기존 쿼리 : 1853 ms
- OFFSET 0, like_count 인덱스를 드라이빙 테이블로 삼는 경우 : 7ms
- OFFSET 1000, like_count 인덱스를 드라이빙 테이블로 삼는 경우 : 942ms
- OFFSET 과 상관 없이 travelogue_tag 를 드라이빙 테이블로 삼는 경우 : 158ms

### **최대 1853 ms -> 7 ms 로 264배 개선하였습니다.**


내용이 많이 길고 복잡한데, 자세한 내용은 떼껄룩에 적었으니 참고해주세요.
https://shelled-operation-d0b.notion.site/a89fa9fd93354c1db4efaef27a78b763?pvs=74