### PR TITLE
[Fix] - 다중 환경에서 배치 작업이 여러번 실행되는 오류 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeSyncService.java
+++ b/backend/src/main/java/kr/touroot/travelogue/service/TravelogueLikeSyncService.java
@@ -3,6 +3,8 @@ package kr.touroot.travelogue.service;
 import kr.touroot.travelogue.repository.TravelogueRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class TravelogueLikeSyncService {
 
+    private static final String LOCK_NAME = "syncLikeCountsWeekly";
+
     private final TravelogueRepository travelogueRepository;
+    private final RedissonClient redissonClient;
 
     /**
      * 매주 월요일 오전 3시에 좋아요 개수를 동기화
@@ -20,8 +25,15 @@ public class TravelogueLikeSyncService {
     @Scheduled(cron = "0 0 3 * * MON")
     @Transactional
     public void syncLikeCountsWeekly() {
-        log.info("Starting weekly like count sync...");
-        travelogueRepository.syncLikeCounts();
-        log.info("Weekly like count sync completed.");
+        RLock lock = redissonClient.getLock(LOCK_NAME);
+        if (lock.tryLock()) {
+            try {
+                log.info("Start sync like counts");
+                travelogueRepository.syncLikeCounts();
+                log.info("End sync like counts");
+            } finally {
+                lock.unlock();
+            }
+        }
     }
 }

--- a/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeSyncServiceTest.java
+++ b/backend/src/test/java/kr/touroot/travelogue/service/TravelogueLikeSyncServiceTest.java
@@ -1,0 +1,44 @@
+package kr.touroot.travelogue.service;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.times;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import kr.touroot.global.AbstractServiceIntegrationTest;
+import kr.touroot.travelogue.repository.TravelogueRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@DisplayName("좋아요 개수 동기화 테스트")
+class TravelogueLikeSyncServiceTest extends AbstractServiceIntegrationTest {
+
+    @SpyBean
+    private TravelogueLikeSyncService travelogueLikeSyncService;
+    @MockBean
+    private TravelogueRepository travelogueRepository;
+
+    @DisplayName("여러 스레드가 동시에 동기화를 시도하는 경우 하나의 스레드만 성공한다")
+    @Test
+    void syncLikeCountsWeekly() {
+        // given & when
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                travelogueLikeSyncService.syncLikeCountsWeekly();
+                latch.countDown();
+            });
+        }
+
+        // then
+        await().atMost(Duration.ofSeconds(10)).until(() -> latch.getCount() == 0);
+        Mockito.verify(travelogueRepository, times(1)).syncLikeCounts();
+    }
+}


### PR DESCRIPTION
# ✅ 작업 내용

- [x] 다중 환경에서 @Scheduled 작업이 여러 서버에서 동시에 실행되는 현상 수정

# 🙈 참고 사항
좋아요 개수를 동기화하는 작업이 여러 서버 노드에서 중복으로 실행될 수 있습니다. 이 문제를 해결하기 위해 분산락을 활용했습니다.
방대한 데이터 크기를 다루는 만큼 spin lock 방식의 오버헤드를 고려해서 Redisson 클라이언트를 사용했습니다.
다만 여러 서버 노드가 모두 동기화할 책임이 있는 것은 아니므로 락을 획득하지 못한 경우 트랜잭션이 소멸되도록 분기 처리하였습니다.

https://github.com/woowacourse-teams/2024-touroot/issues/661
