### PR TITLE
[Feature] - BE 테스트 개선 Bean Lazy Initialization 도입

### DIFF
--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -23,6 +23,8 @@ cloud:
 server:
   port: 8081
 spring:
+  main:
+    lazy-initialization: true
   config:
     activate:
       on-profile: test


### PR DESCRIPTION
# ✅ 작업 내용

- 스프링 어플리케이션 컨텍스트가 뜰 때 빈을 바로 생성하는 것이 아닌 lazy 하게 생성하도록 설정

# 🙈 참고 사항
기본적으로 스프링은 어플리케이션 컨텍스트가 뜰 때 모든 빈을 바로 생성합니다.

저희 테스트에서는 여러 개의 어플리케이션 컨텍스트가 뜨는데, 
각 컨텍스트마다 모든 빈을 사용하지 않기 때문에 lazy 옵션을 주어 최적화 했습니다.
(해당 빈이 필요해지는 순간에 생성)

하지만 생각보다 개선이 크지는 않습니다.
제 로컬 기준 1m 32.7s -> 1m 24.3s 로 약 10% 정도 개선되었습니다.

스프링 어플리케이션 컨텍스트의 개수가 4개이고, 빈 개수 자체도 많지 않다 보니 유의미한 차이를 보이지는 않는 것 같습니다.